### PR TITLE
Link the GitHub repository from the site

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -77,6 +77,11 @@ export default defineConfig({
     // The site is a single landing page; only /privacy and /licenses use
     // this default-theme chrome.
     nav: [{ text: 'Home', link: '/' }],
+    // GitHub icon in that default-theme navbar. The landing page's own nav
+    // and footer carry the same link, driven by index.md frontmatter.
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/keelapps/keelhaven' },
+    ],
     footer: {
       // The BSD-2-Clause notice travels with the app bundle (restic-LICENSE.txt
       // + the About window) — the website distributes nothing, so a discreet

--- a/site/.vitepress/theme/components/LandingFooter.vue
+++ b/site/.vitepress/theme/components/LandingFooter.vue
@@ -16,12 +16,19 @@ const href = (link: {
   href?: string
   anchor?: string
   mailto?: boolean
+  github?: boolean
 }) => {
   if (link.mailto) return `mailto:${landing.value.contact}`
+  if (link.github) return landing.value.github
   if (link.anchor) return `#${link.anchor}`
   if (link.href) return link.href
   return withBase(link.link ?? '/')
 }
+
+// Off-site links open in a new tab — VitePress does this for markdown links,
+// but these anchors are rendered by hand.
+const external = (link: { href?: string; github?: boolean }) =>
+  Boolean(link.href || link.github)
 </script>
 
 <template>
@@ -40,7 +47,11 @@ const href = (link: {
           <h4>{{ group.title }}</h4>
           <ul>
             <li v-for="link in group.links" :key="link.text">
-              <a :href="href(link)">{{ link.text }}</a>
+              <a
+                :href="href(link)"
+                :target="external(link) ? '_blank' : undefined"
+                :rel="external(link) ? 'noopener' : undefined"
+              >{{ link.text }}</a>
             </li>
           </ul>
         </div>

--- a/site/.vitepress/theme/components/LandingNav.vue
+++ b/site/.vitepress/theme/components/LandingNav.vue
@@ -63,6 +63,22 @@ const mailto = computed(
           :class="{ active: item.anchor && active === item.anchor }"
         >{{ item.text }}</a>
       </div>
+      <!-- Always visible, unlike the scroll-gated CTA next to it. -->
+      <a
+        v-if="landing.github"
+        class="kh-nav-github"
+        :href="landing.github"
+        target="_blank"
+        rel="noopener"
+        aria-label="Source on GitHub"
+      >
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"
+          />
+        </svg>
+      </a>
       <a class="kh-btn kh-btn-primary kh-nav-cta" :href="mailto">
         {{ landing.cta }}
       </a>

--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -200,6 +200,20 @@ body:has(.kh-landing) .VPLocalNav {
   color: var(--kh-ink);
 }
 
+.kh-landing .kh-nav-github {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  color: var(--kh-ink-soft);
+  transition: color 0.15s ease;
+}
+.kh-landing .kh-nav-github:hover {
+  color: var(--kh-ink);
+}
+
 .kh-landing .kh-nav-cta {
   padding: 8px 18px;
   font-size: 14px;

--- a/site/index.md
+++ b/site/index.md
@@ -10,6 +10,10 @@ landing:
   # Routing alias on keelhaven.app that forwards to a real inbox, so it can be
   # re-pointed without touching the site.
   contact: support@keelhaven.app
+  # The repository URL, read by the nav icon and the footer's github link.
+  # The default-theme pages (/privacy, /licenses) carry it separately via
+  # themeConfig.socialLinks in config.mts.
+  github: https://github.com/keelapps/keelhaven
   cta: Get early access
   ctaSubject: Keelhaven early access
   nav:
@@ -31,6 +35,7 @@ landing:
           - { text: Features, anchor: features }
           - { text: Getting started, anchor: guide }
           - { text: Pricing, anchor: pricing }
+          - { text: Source on GitHub, github: true }
       - title: Legal
         links:
           - { text: Privacy, link: /privacy }


### PR DESCRIPTION
## Why

The repo is public now, but keelhaven.app had no visible way to reach it — the only links sat inside two FAQ answers.

## What

Three placements, one source of truth:

- **Landing nav**: a GitHub icon after the section links, always visible (unlike the scroll-gated CTA), on desktop and mobile.
- **Landing footer**: "Source on GitHub" in the Product group, via a `github: true` link flag following the existing `mailto: true` pattern. External footer links now open in a new tab with `rel="noopener"`.
- **Default-theme pages** (`/privacy`, `/licenses`): `themeConfig.socialLinks`, rendered in their navbar.

The URL is written once in `index.md` frontmatter (`landing.github`) so the planned zh locale inherits it; the socialLinks copy in `config.mts` is locale-independent anyway.

## Verified

- `vitepress build` passes; the link appears in the rendered HTML of all three pages.
- Headless-browser screenshots checked at 1280px and 375px — the mobile pill nav fits with the icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)