### PR TITLE
Move developer documentation from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,94 @@ Bug reports and pull requests are welcome. For anything bigger than a small
 fix, open an issue first so nobody builds the same thing twice — and check the
 "deliberately not built yet" list in `CLAUDE.md` before proposing features.
 
+## Development setup
+
+Common tasks are wrapped in a thin Makefile — run `make` to list them:
+
+```bash
+git clone git@github.com:keelapps/keelhaven.git && cd keelhaven
+make bootstrap   # brew install restic xcodegen gh
+make test        # KeelhavenCore tests, incl. the real-restic integration suite
+make build       # vendor restic + xcodegen generate + Release xcodebuild
+make install     # build from source and install to /Applications
+make update      # install the latest CI build instead (no local build)
+```
+
+The Makefile is a task index only — logic lives in `Scripts/*.sh` and the
+standard tools, so `xcodegen generate` + opening `Keelhaven.xcodeproj` in
+Xcode works exactly the same.
+
+The app ships with its own copy of restic (universal binary, checksum-verified
+against the official release) in `Contents/MacOS/` — end users never install
+anything. A user-set path override and Homebrew locations remain as fallbacks.
+
+### Manual smoke test
+
+1. Run the app — it appears in the menu bar only (no Dock icon).
+2. *Add Backup Plan…* → 3-step wizard → use a temp folder as a local destination.
+3. *Back Up Now* → progress appears in the menu bar → completion notification.
+4. Verify independently: `restic snapshots -r <destination-folder>` (with the password you chose).
+
+## Install from CI (personal use)
+
+**Use the install script** — it downloads the newest successful build for your
+Mac's architecture, replaces /Applications/Keelhaven.app, strips quarantine,
+quits any running copy, and launches the new one:
+
+```bash
+./Scripts/install-latest.sh        # needs: brew install gh (authenticated)
+```
+
+<details>
+<summary>Manual fallback (what the script automates)</summary>
+
+Builds are made on demand, not on every push — macOS runners bill at 10× and
+nobody downloads most of them. Trigger one at [Actions](../../actions) →
+Build app → Run workflow (pick your architecture), then download
+`Keelhaven-<n>-apple-silicon` (M-series Macs) or `Keelhaven-<n>-intel`. The
+script above does exactly this for you, reusing an existing artifact when one
+already matches `main`.
+
+GitHub wraps every artifact in its own zip, so the download is a **zip inside a
+zip**: `Keelhaven-<n>-<arch>.zip` contains `Keelhaven.app.zip`, which contains
+the app. Install with:
+
+```bash
+cd ~/Downloads
+unzip -o Keelhaven-*-apple-silicon.zip      # unwraps GitHub's layer → Keelhaven.app.zip
+ditto -x -k Keelhaven.app.zip /Applications # extracts Keelhaven.app (permissions intact)
+xattr -dr com.apple.quarantine /Applications/Keelhaven.app
+open /Applications/Keelhaven.app
+```
+
+Quit the old copy first (menu bar → Quit Keelhaven); a menu-bar app that is
+already running shows nothing when you double-click it again.
+
+</details>
+
+The inner `Keelhaven.app.zip` is deliberate: GitHub's own artifact zip does not
+preserve executable permissions, so the app is ditto-zipped first — never skip
+the second extraction step.
+
+The `xattr` step is required: downloaded apps get macOS's quarantine flag, and
+ad-hoc-signed (un-notarized) apps are blocked by Gatekeeper until it's removed.
+This is fine for installing on your own Macs; release DMGs currently ship
+un-notarized too, with the same one-time approval — the release notes and the
+site FAQ walk through it.
+
+## Project layout
+
+| Path | What it is |
+|---|---|
+| `KeelhavenCore/` | SwiftPM package: restic process runner, JSON parsing, models, persistence, schedule math. UI-free and fully unit-tested. |
+| `KeelhavenCore/Tests/…/Fixtures/` | Unmodified `restic --json` output captured from restic 0.19.1 — parsers are written against real data, not docs. |
+| `Keelhaven/` | SwiftUI app: menu bar, wizard, services (scheduler, notifications, login item, Keychain wiring). |
+| `project.yml` | XcodeGen spec — the `.xcodeproj` is generated, never committed. |
+| `design/` | Icon and brand kit. `icon.mjs` holds the geometry; `build.mjs` renders the asset catalog, `.icns` and favicons. See `design/README.md`. |
+| `site/` | Public website + docs (VitePress). Built and published to this repo's `gh-pages` branch by `.github/workflows/website.yml`, served at [keelhaven.app](https://keelhaven.app). See `docs/WEBSITE.md`. |
+| `docs/ARCHITECTURE.md` | Module boundaries, data flow, and upgrade paths. |
+| `docs/WEBSITE.md` | How the site is built, deployed, and how the keelhaven.app domain is wired. |
+
 ## Licensing of contributions
 
 Keelhaven is licensed under GPL-3.0-or-later (see `LICENSE`). The plan that

--- a/README.md
+++ b/README.md
@@ -30,93 +30,12 @@ Applications. Either way, beta builds aren't notarized yet, so the very first
 launch needs a one-time approval — the [site FAQ](https://keelhaven.app/#faq)
 walks through it.
 
-## Install from CI (personal use)
+## Contributing and development
 
-**Use the install script** — it downloads the newest successful build for your
-Mac's architecture, replaces /Applications/Keelhaven.app, strips quarantine,
-quits any running copy, and launches the new one:
-
-```bash
-./Scripts/install-latest.sh        # needs: brew install gh (authenticated)
-```
-
-<details>
-<summary>Manual fallback (what the script automates)</summary>
-
-Builds are made on demand, not on every push — macOS runners bill at 10× and
-nobody downloads most of them. Trigger one at [Actions](../../actions) →
-Build app → Run workflow (pick your architecture), then download
-`Keelhaven-<n>-apple-silicon` (M-series Macs) or `Keelhaven-<n>-intel`. The
-script above does exactly this for you, reusing an existing artifact when one
-already matches `main`.
-
-GitHub wraps every artifact in its own zip, so the download is a **zip inside a
-zip**: `Keelhaven-<n>-<arch>.zip` contains `Keelhaven.app.zip`, which contains
-the app. Install with:
-
-```bash
-cd ~/Downloads
-unzip -o Keelhaven-*-apple-silicon.zip      # unwraps GitHub's layer → Keelhaven.app.zip
-ditto -x -k Keelhaven.app.zip /Applications # extracts Keelhaven.app (permissions intact)
-xattr -dr com.apple.quarantine /Applications/Keelhaven.app
-open /Applications/Keelhaven.app
-```
-
-Quit the old copy first (menu bar → Quit Keelhaven); a menu-bar app that is
-already running shows nothing when you double-click it again.
-
-</details>
-
-The inner `Keelhaven.app.zip` is deliberate: GitHub's own artifact zip does not
-preserve executable permissions, so the app is ditto-zipped first — never skip
-the second extraction step.
-
-The `xattr` step is required: downloaded apps get macOS's quarantine flag, and
-ad-hoc-signed (un-notarized) apps are blocked by Gatekeeper until it's removed.
-This is fine for installing on your own Macs; release DMGs currently ship
-un-notarized too, with the same one-time approval — the release notes and the
-site FAQ walk through it.
-
-## Development setup
-
-Common tasks are wrapped in a thin Makefile — run `make` to list them:
-
-```bash
-git clone git@github.com:keelapps/keelhaven.git && cd keelhaven
-make bootstrap   # brew install restic xcodegen gh
-make test        # KeelhavenCore tests, incl. the real-restic integration suite
-make build       # vendor restic + xcodegen generate + Release xcodebuild
-make install     # build from source and install to /Applications
-make update      # install the latest CI build instead (no local build)
-```
-
-The Makefile is a task index only — logic lives in `Scripts/*.sh` and the
-standard tools, so `xcodegen generate` + opening `Keelhaven.xcodeproj` in
-Xcode works exactly the same.
-
-The app ships with its own copy of restic (universal binary, checksum-verified
-against the official release) in `Contents/MacOS/` — end users never install
-anything. A user-set path override and Homebrew locations remain as fallbacks.
-
-### Manual smoke test
-
-1. Run the app — it appears in the menu bar only (no Dock icon).
-2. *Add Backup Plan…* → 3-step wizard → use a temp folder as a local destination.
-3. *Back Up Now* → progress appears in the menu bar → completion notification.
-4. Verify independently: `restic snapshots -r <destination-folder>` (with the password you chose).
-
-## Project layout
-
-| Path | What it is |
-|---|---|
-| `KeelhavenCore/` | SwiftPM package: restic process runner, JSON parsing, models, persistence, schedule math. UI-free and fully unit-tested. |
-| `KeelhavenCore/Tests/…/Fixtures/` | Unmodified `restic --json` output captured from restic 0.19.1 — parsers are written against real data, not docs. |
-| `Keelhaven/` | SwiftUI app: menu bar, wizard, services (scheduler, notifications, login item, Keychain wiring). |
-| `project.yml` | XcodeGen spec — the `.xcodeproj` is generated, never committed. |
-| `design/` | Icon and brand kit. `icon.mjs` holds the geometry; `build.mjs` renders the asset catalog, `.icns` and favicons. See `design/README.md`. |
-| `site/` | Public website + docs (VitePress). Built and published to this repo's `gh-pages` branch by `.github/workflows/website.yml`, served at [keelhaven.app](https://keelhaven.app). See `docs/WEBSITE.md`. |
-| `docs/ARCHITECTURE.md` | Module boundaries, data flow, and upgrade paths. |
-| `docs/WEBSITE.md` | How the site is built, deployed, and how the keelhaven.app domain is wired. |
+Keelhaven is developed in the open. Development setup, the CI install path
+for personal builds, and the project layout live in
+[CONTRIBUTING.md](CONTRIBUTING.md); module boundaries and design decisions in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Security model (v1)
 


### PR DESCRIPTION
## Summary

The README mixed user-facing content with sections only contributors need. This moves the developer-oriented material into `CONTRIBUTING.md`, leaving the README focused on what a user of the app needs.

## Key changes

- **Moved to `CONTRIBUTING.md`** (content unchanged, reordered for a new contributor: setup → smoke test → CI installs → layout → licensing terms):
  - *Development setup* (Makefile tasks, bundled-restic note) with the *Manual smoke test*
  - *Install from CI (personal use)*, including the manual-fallback details and the zip-in-zip / `xattr` explanations
  - *Project layout* table
- **README** keeps Install, Security model, and License, and gains a short *Contributing and development* section pointing at `CONTRIBUTING.md` and `docs/ARCHITECTURE.md`.

No prose was rewritten beyond the new pointer section — the sections moved verbatim, so relative links (`../../actions`) still resolve the same from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqxesLE6HaNsR3NVbo3YY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqxesLE6HaNsR3NVbo3YY8)_