### PR TITLE
Fix nav download saving the DMG as a file named "true"

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -72,7 +72,7 @@ export default defineConfig({
     // site/privacy.md discloses it and must change in step with this block.
     [
       'script',
-      { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-C671MMNMGY' },
+      { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-WWCP7VVJPM' },
     ],
     [
       'script',

--- a/site/.vitepress/theme/components/LandingNav.vue
+++ b/site/.vitepress/theme/components/LandingNav.vue
@@ -80,10 +80,14 @@ const ctaHref = computed(
           />
         </svg>
       </a>
+      <!-- `download` must be empty, not a boolean: its value is the suggested
+           filename, so `download="true"` saves the DMG as a file named "true".
+           Empty keeps the filename from the URL and still stops VitePress's
+           SPA router from intercepting the click. -->
       <a
         class="kh-btn kh-btn-primary kh-nav-cta"
         :href="ctaHref"
-        :download="Boolean(dmgURL) || undefined"
+        :download="dmgURL ? '' : undefined"
       >
         {{ landing.cta }}
       </a>


### PR DESCRIPTION
## Summary

Clicking the nav's Download button saved the DMG as a file literally named `true` (reported from https://keelhaven.app/#guide). This fixes the attribute binding and also aligns the two Google Analytics IDs that had drifted apart.

## Key changes

- **`LandingNav.vue`**: the CTA bound its `download` attribute as a boolean, which Vue renders as `download="true"` — and the attribute's value is the *suggested filename*, so the browser saved the DMG as `true`. It now binds an empty string when the DMG link is live: the browser keeps the filename from the URL (`Keelhaven-0.1.0.dmg`), and the attribute still stops VitePress's SPA router from intercepting the click. The hero button already used a bare `download` and was unaffected.
- **`config.mts`**: the gtag.js loader URL still said `G-C671MMNMGY` while the `gtag('config', …)` call had been updated to `G-WWCP7VVJPM`; the loader now uses the same ID.

## Verification

Built the site, stubbed `latest.json`, and drove it with a real Chromium: both the hero button and the scroll-revealed nav CTA now resolve to the DMG URL with `download=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqxesLE6HaNsR3NVbo3YY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqxesLE6HaNsR3NVbo3YY8)_