### PR TITLE
ci: bump action-gh-release to v3 for the Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish GitHub Release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: Keelhaven-${{ steps.version.outputs.version }}.dmg
           body_path: release-note.md


### PR DESCRIPTION
Fixes the deprecation warning in the `Build, package, publish` job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: softprops/action-gh-release@v2.

[softprops/action-gh-release v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) is a major release whose only change is moving the action runtime from Node 20 to Node 24 — no input or behavior changes, and the `v2` floating tag will stay on Node 20 forever. The inputs this workflow uses (`files`, `body_path`, `generate_release_notes`) are unchanged in v3.

Also checked the other third-party actions in this repo: `peaceiris/actions-gh-pages@v4` already resolves to v4.1.0, which targets Node 24, and the `actions/*` ones are current — no other bumps needed.