### PR TITLE
Make the guide's terminal install commands scannable

### DIFF
--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -546,7 +546,38 @@ body:has(.kh-landing) .VPLocalNav {
   max-width: 72ch;
 }
 .kh-landing .kh-guide-note p {
-  margin: 0;
+  margin: 0 0 14px;
+}
+.kh-landing .kh-guide-note p:last-child {
+  margin-bottom: 0;
+}
+.kh-landing .kh-install {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 14px;
+}
+.kh-landing .kh-install-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+}
+.kh-landing .kh-install-label {
+  flex: none;
+  width: 132px;
+  font-size: 13.5px;
+  color: var(--kh-ink-soft);
+}
+.kh-landing .kh-install code {
+  font-size: 13px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--kh-chip);
+  border: 1px solid var(--kh-line);
+  user-select: all;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-width: 100%;
 }
 
 /* ---------- footer ---------- */

--- a/site/index.md
+++ b/site/index.md
@@ -146,7 +146,14 @@ Hourly, daily, or weekly. Keelhaven runs in the background and only speaks up wh
 
 <div class="kh-guide-note">
 
-Runs on macOS 14 or later, Apple silicon and Intel, with everything it needs bundled. Prefer the terminal? `brew install --cask keelapps/tap/keelhaven`, or without Homebrew: `curl -fsSL https://keelhaven.app/install.sh | bash`. Beta builds aren't notarised by Apple yet, so the very first launch takes one extra approval — the [FAQ below](#faq) walks through it in three clicks.
+Runs on macOS 14 or later, Apple silicon and Intel, with everything it needs bundled. Prefer the terminal? Either command installs the same app the download button serves:
+
+<div class="kh-install">
+  <div class="kh-install-row"><span class="kh-install-label">With Homebrew</span><code>brew install --cask keelapps/tap/keelhaven</code></div>
+  <div class="kh-install-row"><span class="kh-install-label">Without Homebrew</span><code>curl -fsSL https://keelhaven.app/install.sh | bash</code></div>
+</div>
+
+Beta builds aren't notarised by Apple yet, so the very first launch takes one extra approval — the [FAQ below](#faq) walks through it in three clicks.
 
 </div>
 


### PR DESCRIPTION
## What

The guide's install note crammed both terminal commands into one running sentence, so neither stood out. This lays them out as labeled rows instead:

- **With Homebrew** → `brew install --cask keelapps/tap/keelhaven`
- **Without Homebrew** → `curl -fsSL https://keelhaven.app/install.sh | bash`

The intro line now says both commands install the same DMG the download button serves, and the notarisation note gets its own paragraph after the commands.

## How

- `site/index.md`: split the `kh-guide-note` paragraph into intro → command rows → notarisation note.
- `landing.css`: new `.kh-install` styles reusing the hero install chip look (`--kh-chip`/`--kh-line`, `user-select: all` so one click selects the whole command). Commands wrap on narrow screens (`pre-wrap` + `overflow-wrap: anywhere`) so nothing is clipped on mobile.

Verified with a local VitePress build and screenshots at desktop (1280px), mobile (375px), and dark mode.

Site-only change — the macOS CI suite skips it by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)