### PR TITLE
Scheduled repository verification (restic check)

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -6,6 +6,7 @@ import KeelhavenCore
 enum PlanRunState: Equatable {
     case idle
     case running(progress: Double)
+    case checking
     case succeeded(Date)
     case failed(String)
 }
@@ -113,7 +114,12 @@ final class AppState {
 
     var menuBarIcon: MenuBarIcon {
         let states = runStates.values
-        if states.contains(where: { if case .running = $0 { return true }; return false }) {
+        if states.contains(where: {
+            switch $0 {
+            case .running, .checking: return true
+            default: return false
+            }
+        }) {
             return .symbol("arrow.triangle.2.circlepath")
         }
         if states.contains(where: { if case .failed = $0 { return true }; return false }) {
@@ -148,7 +154,7 @@ final class AppState {
         }
     }
 
-    /// Applies an Edit Plan save. Mutates the four editable fields in place —
+    /// Applies an Edit Plan save. Mutates the five editable fields in place —
     /// never replaces the whole struct, so a backup finishing concurrently
     /// keeps its `lastRun` write (`finishRun` mutates the same array slot).
     func updatePlan(
@@ -156,7 +162,8 @@ final class AppState {
         name: String,
         sourcePaths: [String],
         excludePatterns: [String],
-        schedule: Schedule
+        schedule: Schedule,
+        checkCadence: CheckCadence
     ) {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, !sourcePaths.isEmpty,
@@ -165,13 +172,14 @@ final class AppState {
         plans[index].sourcePaths = sourcePaths
         plans[index].excludePatterns = excludePatterns
         plans[index].schedule = schedule
+        plans[index].checkCadence = checkCadence
         Task {
             try? await planStore.save(plans)
         }
     }
 
     func deletePlan(_ plan: BackupPlan) {
-        guard !isBackupRunning else { return }
+        guard !isResticBusy else { return }
         plans.removeAll { $0.id == plan.id }
         runStates.removeValue(forKey: plan.id)
         planManager.removeSecrets(planID: plan.id)
@@ -183,12 +191,20 @@ final class AppState {
 
     // MARK: - Running backups
 
-    var isBackupRunning: Bool {
-        runStates.values.contains { if case .running = $0 { return true }; return false }
+    /// True while any plan has a restic process going — a backup or a
+    /// repository check. One restic at a time, app-wide: two invocations
+    /// would contend for the repository lock.
+    var isResticBusy: Bool {
+        runStates.values.contains {
+            switch $0 {
+            case .running, .checking: return true
+            default: return false
+            }
+        }
     }
 
     private func runDuePlans() {
-        guard !isBackupRunning else { return }
+        guard !isResticBusy else { return }
         let now = Date()
         if let due = plans.first(where: { SchedulePolicy.isDue($0, now: now) }) {
             runBackup(due)
@@ -196,7 +212,7 @@ final class AppState {
     }
 
     func runBackup(_ plan: BackupPlan) {
-        guard !isBackupRunning else { return }
+        guard !isResticBusy else { return }
         guard let binaryURL = resticBinaryURL else {
             runStates[plan.id] = .failed(ResticError.binaryNotFound.localizedDescription)
             return
@@ -241,6 +257,14 @@ final class AppState {
             await finishRun(plan, record: record)
             runStates[plan.id] = .succeeded(Date())
             await NotificationService.postBackupFinished(planName: plan.name, summary: summary)
+            // Verification rides on the tail of a successful backup: the
+            // destination is provably reachable and restic is already
+            // serialized, so a due check can never fire a false alarm about
+            // an unplugged drive or overlap another invocation.
+            if let current = plans.first(where: { $0.id == plan.id }),
+               CheckPolicy.isDue(current, now: Date()) {
+                await performCheck(current, binaryURL: binaryURL)
+            }
         } catch {
             let message = (error as? ResticError)?.localizedDescription ?? error.localizedDescription
             let record = BackupRunRecord(date: startedAt, success: false, errorMessage: message)
@@ -256,6 +280,64 @@ final class AppState {
         }
         try? await planStore.save(plans)
         try? await historyStore.append(record, planID: plan.id)
+    }
+
+    // MARK: - Repository checks
+
+    /// The "Verify Backup Now" action. Scheduled checks don't come through
+    /// here — they chain off `performBackup` so the destination is known
+    /// reachable.
+    func runCheck(_ plan: BackupPlan) {
+        guard !isResticBusy else { return }
+        guard let binaryURL = resticBinaryURL else {
+            runStates[plan.id] = .failed(ResticError.binaryNotFound.localizedDescription)
+            return
+        }
+        Task {
+            await self.performCheck(plan, binaryURL: binaryURL)
+        }
+    }
+
+    private func performCheck(_ plan: BackupPlan, binaryURL: URL) async {
+        let stateBefore = runStates[plan.id] ?? .idle
+        runStates[plan.id] = .checking
+        let startedAt = Date()
+        do {
+            let credentials = try credentials(for: plan)
+            let runner = ResticRunner(binaryURL: binaryURL)
+            try await runner.runIgnoringOutput(
+                .check,
+                destination: plan.destination,
+                credentials: credentials
+            )
+            await finishCheck(plan, record: CheckRunRecord(
+                date: startedAt,
+                success: true,
+                duration: Date().timeIntervalSince(startedAt)
+            ))
+            runStates[plan.id] = stateBefore
+            // Success is silent — the plan row's "Verified" line is enough.
+        } catch {
+            let message = (error as? ResticError)?.localizedDescription ?? error.localizedDescription
+            await finishCheck(plan, record: CheckRunRecord(
+                date: startedAt,
+                success: false,
+                duration: Date().timeIntervalSince(startedAt),
+                errorMessage: message
+            ))
+            // Back to idle, not `stateBefore`: a post-backup `.succeeded`
+            // would keep the health dot green while the persistent
+            // failed-check line (read in the idle branch) must turn it red.
+            runStates[plan.id] = .idle
+            await NotificationService.postCheckFailed(planName: plan.name, message: message)
+        }
+    }
+
+    private func finishCheck(_ plan: BackupPlan, record: CheckRunRecord) async {
+        if let index = plans.firstIndex(where: { $0.id == plan.id }) {
+            plans[index].lastCheck = record
+        }
+        try? await planStore.save(plans)
     }
 
     /// For the Touch ID–gated "Copy Repository Password" action only.

--- a/Keelhaven/EditPlan/EditPlanModel.swift
+++ b/Keelhaven/EditPlan/EditPlanModel.swift
@@ -13,6 +13,7 @@ final class EditPlanModel {
     var scheduleKind: ScheduleKind = .daily
     var dailyTime = Schedule.defaultDailyTime
     var weekday = Calendar.current.firstWeekday
+    var checkCadence: CheckCadence = .weekly
     /// Scratch field for the exclude-pattern TextField.
     var newExcludePattern = ""
 
@@ -21,6 +22,7 @@ final class EditPlanModel {
         sourcePaths = plan.sourcePaths
         excludePatterns = plan.excludePatterns
         (scheduleKind, dailyTime, weekday) = plan.schedule.editorComponents
+        checkCadence = plan.checkCadence
         newExcludePattern = ""
     }
 

--- a/Keelhaven/EditPlan/EditPlanWindowView.swift
+++ b/Keelhaven/EditPlan/EditPlanWindowView.swift
@@ -45,6 +45,8 @@ struct EditPlanWindowView: View {
                 .font(.headline)
             ScheduleEditor(kind: $model.scheduleKind, dailyTime: $model.dailyTime, weekday: $model.weekday)
 
+            verificationSection
+
             destinationRow(for: plan)
 
             excludeSection
@@ -62,7 +64,8 @@ struct EditPlanWindowView: View {
                         name: model.name,
                         sourcePaths: model.sourcePaths,
                         excludePatterns: model.excludePatterns,
-                        schedule: model.builtSchedule()
+                        schedule: model.builtSchedule(),
+                        checkCadence: model.checkCadence
                     )
                     dismiss()
                 }
@@ -117,6 +120,24 @@ struct EditPlanWindowView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+        }
+    }
+
+    private var verificationSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Verification")
+                .font(.headline)
+            Picker("Verification", selection: $model.checkCadence) {
+                Text("Weekly").tag(CheckCadence.weekly)
+                Text("Monthly").tag(CheckCadence.monthly)
+                Text("Off").tag(CheckCadence.off)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 260)
+            Text("Runs restic's own repository check after a backup, and only speaks up when something is wrong.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Keelhaven/MenuBar/PlanHealth.swift
+++ b/Keelhaven/MenuBar/PlanHealth.swift
@@ -13,13 +13,17 @@ enum PlanHealth {
 extension BackupPlan {
     func health(runState: PlanRunState) -> PlanHealth {
         switch runState {
-        case .running:
+        case .running, .checking:
             return .running
         case .failed:
             return .needsAttention
         case .succeeded:
             return .ok
         case .idle:
+            // A failed integrity check outranks a good backup: the backups
+            // exist but may not be restorable, which is the one thing this
+            // dot must never show green for.
+            if let lastCheck, !lastCheck.success { return .needsAttention }
             guard let lastRun else { return .neverBackedUp }
             return lastRun.success ? .ok : .needsAttention
         }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -84,6 +84,11 @@ struct PlanStatusRow: View {
                 .foregroundStyle(.secondary)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(String(localized: "Schedule: \(plan.schedule.displayText)"))
+                // Absent until the first check so a fresh plan stays
+                // uncluttered; red is reserved for an actual failed check.
+                if let lastCheck = plan.lastCheck {
+                    verificationLine(lastCheck)
+                }
                 statusLine
             }
         }
@@ -115,6 +120,10 @@ struct PlanStatusRow: View {
             openWindow(id: WindowID.restore)
             NSApp.activate(ignoringOtherApps: true)
         }
+        Button("Verify Backup Now") {
+            appState.runCheck(plan)
+        }
+        .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
         Button("Edit Plan…") {
             appState.editPlanID = plan.id
             openWindow(id: WindowID.editPlan)
@@ -130,7 +139,7 @@ struct PlanStatusRow: View {
         Button("Delete Backup Plan…", role: .destructive) {
             confirmAndDelete()
         }
-        .disabled(appState.isBackupRunning)
+        .disabled(appState.isResticBusy)
     }
 
     /// Confirmation dialogs use app-modal NSAlert, not SwiftUI `.alert`:
@@ -204,8 +213,28 @@ struct PlanStatusRow: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.regular)
-            .disabled(appState.isBackupRunning || appState.resticBinaryURL == nil)
+            .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
         }
+    }
+
+    private func verificationLine(_ check: CheckRunRecord) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: check.success ? "checkmark.shield" : "exclamationmark.shield")
+            if check.success {
+                Text("Verified \(check.date.formatted(date: .abbreviated, time: .omitted))")
+            } else {
+                Text("Verification failed")
+            }
+        }
+        .font(.callout)
+        .foregroundStyle(check.success ? AnyShapeStyle(.secondary) : AnyShapeStyle(.red))
+        .help(check.success
+            ? String(localized: "restic reported the repository intact on \(check.date.formatted(date: .abbreviated, time: .shortened))")
+            : (check.errorMessage ?? String(localized: "The last repository check failed")))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(check.success
+            ? String(localized: "Backup verified on \(check.date.formatted(date: .abbreviated, time: .omitted))")
+            : String(localized: "Backup verification failed"))
     }
 
     @ViewBuilder
@@ -216,6 +245,16 @@ struct PlanStatusRow: View {
                 .controlSize(.small)
                 .padding(.top, 2)
                 .accessibilityLabel(String(localized: "Backup \(Int(progress * 100)) percent done"))
+        case .checking:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Verifying backup…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "Backup verification running"))
         case .failed(let message):
             Text(message)
                 .font(.callout)

--- a/Keelhaven/Services/NotificationService.swift
+++ b/Keelhaven/Services/NotificationService.swift
@@ -31,6 +31,15 @@ enum NotificationService {
         await post(content)
     }
 
+    /// Only failures notify — a passed check shows quietly in the plan row.
+    static func postCheckFailed(planName: String, message: String) async {
+        let content = UNMutableNotificationContent()
+        content.title = String(localized: "Backup verification failed")
+        content.body = "\(planName): \(message)"
+        content.sound = .default
+        await post(content)
+    }
+
     private static func post(_ content: UNMutableNotificationContent) async {
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
@@ -11,8 +11,10 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
     public var destination: Destination
     public var schedule: Schedule
     public var excludePatterns: [String]
+    public var checkCadence: CheckCadence
     public var createdAt: Date
     public var lastRun: BackupRunRecord?
+    public var lastCheck: CheckRunRecord?
 
     public static let defaultExcludePatterns: [String] = [
         ".DS_Store",
@@ -28,8 +30,10 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         destination: Destination,
         schedule: Schedule,
         excludePatterns: [String] = BackupPlan.defaultExcludePatterns,
+        checkCadence: CheckCadence = .weekly,
         createdAt: Date = Date(),
-        lastRun: BackupRunRecord? = nil
+        lastRun: BackupRunRecord? = nil,
+        lastCheck: CheckRunRecord? = nil
     ) {
         self.id = id
         self.name = name
@@ -37,7 +41,26 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         self.destination = destination
         self.schedule = schedule
         self.excludePatterns = excludePatterns
+        self.checkCadence = checkCadence
         self.createdAt = createdAt
         self.lastRun = lastRun
+        self.lastCheck = lastCheck
+    }
+
+    /// Plans saved before scheduled checks existed lack the two check keys —
+    /// decode them leniently so an upgrade can never lose the plan list.
+    /// (`encode(to:)` and `CodingKeys` stay synthesized.)
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        sourcePaths = try container.decode([String].self, forKey: .sourcePaths)
+        destination = try container.decode(Destination.self, forKey: .destination)
+        schedule = try container.decode(Schedule.self, forKey: .schedule)
+        excludePatterns = try container.decode([String].self, forKey: .excludePatterns)
+        checkCadence = try container.decodeIfPresent(CheckCadence.self, forKey: .checkCadence) ?? .weekly
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        lastRun = try container.decodeIfPresent(BackupRunRecord.self, forKey: .lastRun)
+        lastCheck = try container.decodeIfPresent(CheckRunRecord.self, forKey: .lastCheck)
     }
 }

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/CheckCadence.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/CheckCadence.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// How often a plan's repository is verified with `restic check`.
+/// Deliberately coarser than backup schedules: a check reads repository
+/// metadata, which on a remote destination costs requests and bandwidth,
+/// and its job is catching silent corruption — weekly is plenty.
+public enum CheckCadence: String, Codable, CaseIterable, Hashable, Sendable {
+    case off
+    case weekly
+    case monthly
+}

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/CheckRunRecord.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/CheckRunRecord.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Outcome of a repository integrity check, kept on the plan for the menu
+/// bar and for the next-check due math.
+public struct CheckRunRecord: Codable, Hashable, Sendable {
+    public var date: Date
+    public var success: Bool
+    public var duration: TimeInterval?
+    public var errorMessage: String?
+
+    public init(
+        date: Date,
+        success: Bool,
+        duration: TimeInterval? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.date = date
+        self.success = success
+        self.duration = duration
+        self.errorMessage = errorMessage
+    }
+}

--- a/KeelhavenCore/Sources/KeelhavenCore/Scheduling/CheckPolicy.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Scheduling/CheckPolicy.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Pure due math for scheduled repository checks (`restic check`), kept
+/// timer-free like SchedulePolicy. Checks are interval-based rather than
+/// wall-clock — "at least once a week", not "Sundays at 09:00" — and the app
+/// runs them on the tail of a successful backup, so the destination is known
+/// reachable and the two restic invocations can never contend for the
+/// repository lock.
+public enum CheckPolicy {
+    /// Seconds between checks, or nil when checks are off.
+    public static func interval(for cadence: CheckCadence) -> TimeInterval? {
+        switch cadence {
+        case .off:
+            return nil
+        case .weekly:
+            return 7 * 86400
+        case .monthly:
+            return 30 * 86400
+        }
+    }
+
+    /// Due when checking is on and the last check is at least one interval
+    /// old. The clock counts from the last check whether it passed or failed,
+    /// so a corrupt repository alerts once per cadence instead of after every
+    /// backup. A plan that has never been checked counts from its creation
+    /// date: the repository was created (or adopted, password-proven) moments
+    /// before, so the first verification can wait a full interval.
+    public static func isDue(_ plan: BackupPlan, now: Date) -> Bool {
+        guard let interval = interval(for: plan.checkCadence) else {
+            return false
+        }
+        let anchor = plan.lastCheck?.date ?? plan.createdAt
+        return anchor.addingTimeInterval(interval) <= now
+    }
+}

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/CheckPolicyTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/CheckPolicyTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import KeelhavenCore
+
+final class CheckPolicyTests: XCTestCase {
+    private let created = Date(timeIntervalSince1970: 1_755_200_000)
+    private let week: TimeInterval = 7 * 86400
+    private let month: TimeInterval = 30 * 86400
+
+    private func makePlan(
+        cadence: CheckCadence,
+        lastCheck: CheckRunRecord? = nil
+    ) -> BackupPlan {
+        BackupPlan(
+            name: "Test",
+            sourcePaths: ["/tmp/src"],
+            destination: .local(path: "/tmp/repo"),
+            schedule: .hourly,
+            checkCadence: cadence,
+            createdAt: created,
+            lastCheck: lastCheck
+        )
+    }
+
+    func testIntervalPerCadence() {
+        XCTAssertNil(CheckPolicy.interval(for: .off))
+        XCTAssertEqual(CheckPolicy.interval(for: .weekly), week)
+        XCTAssertEqual(CheckPolicy.interval(for: .monthly), month)
+    }
+
+    func testOffIsNeverDue() {
+        let plan = makePlan(cadence: .off)
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: created.addingTimeInterval(365 * 86400)))
+    }
+
+    func testNeverCheckedPlanCountsFromCreation() {
+        // Not due the moment a plan is created — the repository was just
+        // initialized or password-proven, so the first check waits a full
+        // interval.
+        let plan = makePlan(cadence: .weekly)
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: created))
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: created.addingTimeInterval(week - 1)))
+        XCTAssertTrue(CheckPolicy.isDue(plan, now: created.addingTimeInterval(week)))
+    }
+
+    func testCheckedPlanCountsFromLastCheck() {
+        let checkedAt = created.addingTimeInterval(3 * 86400)
+        let plan = makePlan(
+            cadence: .weekly,
+            lastCheck: CheckRunRecord(date: checkedAt, success: true)
+        )
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: checkedAt.addingTimeInterval(week - 1)))
+        XCTAssertTrue(CheckPolicy.isDue(plan, now: checkedAt.addingTimeInterval(week)))
+    }
+
+    func testFailedCheckStillAdvancesTheClock() {
+        // A failing repository alerts once per cadence, not after every
+        // backup — the anchor is the last attempt, pass or fail.
+        let failedAt = created.addingTimeInterval(week)
+        let plan = makePlan(
+            cadence: .weekly,
+            lastCheck: CheckRunRecord(date: failedAt, success: false, errorMessage: "pack corrupted")
+        )
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: failedAt.addingTimeInterval(86400)))
+        XCTAssertTrue(CheckPolicy.isDue(plan, now: failedAt.addingTimeInterval(week)))
+    }
+
+    func testMonthlyCadence() {
+        let plan = makePlan(
+            cadence: .monthly,
+            lastCheck: CheckRunRecord(date: created, success: true)
+        )
+        XCTAssertFalse(CheckPolicy.isDue(plan, now: created.addingTimeInterval(week)))
+        XCTAssertTrue(CheckPolicy.isDue(plan, now: created.addingTimeInterval(month)))
+    }
+}

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -57,4 +57,51 @@ final class ModelRoundTripTests: XCTestCase {
         )
         XCTAssertEqual(try roundTrip(record), record)
     }
+
+    func testPlanWithCheckFieldsRoundTrip() throws {
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .hourly,
+            checkCadence: .monthly,
+            createdAt: date,
+            lastCheck: CheckRunRecord(
+                date: date,
+                success: false,
+                duration: 12.5,
+                errorMessage: "error: load <data/1234>: invalid data returned"
+            )
+        )
+        XCTAssertEqual(try roundTrip(plan), plan)
+    }
+
+    func testLegacyPlanJSONDecodesWithCheckDefaults() throws {
+        // A plan saved by 0.2.0, before scheduled checks existed: same shape
+        // as today's encoder output minus the two check keys.
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .daily(hour: 21, minute: 30),
+            createdAt: date,
+            lastCheck: CheckRunRecord(date: date, success: true)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoder.encode(plan)) as? [String: Any]
+        )
+        object.removeValue(forKey: "checkCadence")
+        object.removeValue(forKey: "lastCheck")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupPlan.self, from: legacyData)
+        XCTAssertEqual(decoded.checkCadence, .weekly)
+        XCTAssertNil(decoded.lastCheck)
+        XCTAssertEqual(decoded.name, plan.name)
+        XCTAssertEqual(decoded.schedule, plan.schedule)
+    }
 }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -81,6 +81,14 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         XCTAssertEqual(config.version, 2)
         XCTAssertEqual(config.id.count, 64)
 
+        // check: a healthy repository passes the integrity check the
+        // scheduled-verification feature runs
+        try await runner.runIgnoringOutput(
+            .check,
+            destination: destination,
+            credentials: credentials
+        )
+
         // restore the snapshot into a fresh target and verify the files
         let restoreTarget = workDirectory.appendingPathComponent("restored", isDirectory: true)
         var restoreSummary: RestoreSummary?


### PR DESCRIPTION
Implements the first roadmap feature after launch prep: periodic `restic check`, closing the gap the site FAQ currently describes as "on the roadmap".

## Design

- **Checks ride on the tail of a successful backup.** When `CheckPolicy.isDue` says so, `performBackup` chains straight into `restic check` — the destination is provably reachable (an unplugged external drive can never fire a scary verification alarm) and the two restic invocations are naturally serialized. Missed-window catch-up comes free: the check runs after the next backup that succeeds.
- **Cadence per plan: weekly (default) / monthly / off**, editable in Edit Plan. The due clock anchors on the last check *pass or fail* (a corrupt repository alerts once per cadence, not after every hourly backup), and a never-checked plan counts from `createdAt`, so a fresh plan doesn't immediately re-verify the repository it just created. Existing plans decode leniently to weekly — an upgrade can never lose the plan list.
- **Quiet until something is wrong**: success is a subdued `Verified <date>` shield line in the plan row (absent until the first check); failure turns the plan's health dot red — a failed check outranks a good backup, because "backups exist but may not restore" is the one state that must never show green — persists across launches, and posts the only notification.
- **`isBackupRunning` → `isResticBusy`** with a new `.checking` run state, so backups, checks, and Delete stay mutually exclusive app-wide.
- **Manual "Verify Backup Now"** in the plan actions menu for the skeptical-on-demand case.
- Plain `check` (metadata verification), not `--read-data` — the cheap version is the one that can run weekly on remote destinations without a bandwidth bill.

## Verification

- `swift test`: 102 tests pass, **100% line coverage maintained** (new files all 100%: `CheckPolicy`, `CheckRunRecord`, `BackupPlan` incl. the lenient decoder). New `CheckPolicyTests` cover every cadence/anchor branch; a legacy-JSON test proves 0.2.0 plan files decode with weekly/nil defaults; the real-restic integration test now also runs `check` end-to-end (passes in ~7s locally).
- `xcodegen generate && xcodebuild`: **BUILD SUCCEEDED**.

## Release note for 0.3.0

The site FAQ ("How do I know the backups are actually good?") still says scheduled verification is on the roadmap — correct while 0.2.0 is the shipping build. Flip that answer when cutting v0.3.0.