### PR TITLE
Release 0.3.0 prep: one-button publish and content flips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,20 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # A manual run is a dry run by default: it builds the same universal DMG
+  # and uploads it as a workflow artifact, touching nothing public. Tick
+  # `publish` for the one-button release: bump project.yml on main if
+  # needed, create the v<version> tag, publish the GitHub Release (which
+  # triggers website.yml's DMG + latest.json mirror), and bump the tap.
   workflow_dispatch:
     inputs:
       version:
-        description: "Marketing version (e.g. 1.0.0) — only used for a manual run, a tag push derives it from the tag"
-        required: false
+        description: "Marketing version (e.g. 1.0.0) — a tag push derives it from the tag instead"
+        required: true
+      publish:
+        description: "Publish for real: bump project.yml, tag v<version>, GitHub Release, Homebrew tap. Off = build-only dry run."
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -42,6 +51,9 @@ jobs:
       HAS_SIGNING: ${{ secrets.DEVELOPER_ID_CERT_P12_BASE64 != '' }}
       HAS_NOTARY: ${{ secrets.AC_API_KEY_ID != '' }}
       HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+      # True on a tag push and on a manual run with `publish` ticked — every
+      # step that touches the outside world keys off this one flag.
+      PUBLISHING: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -50,14 +62,47 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
-            if [ -z "$VERSION" ]; then
-              echo "::error::version input is required for a manual run" >&2
-              exit 1
-            fi
           else
             VERSION="${GITHUB_REF_NAME#v}"
           fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must look like 1.0.0, got \"$VERSION\"" >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # A manual publish must not be able to release a side branch or reuse
+      # a tag — a tag push proves both by existing.
+      - name: Guard the manual publish
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::publish runs must start from main, not $GITHUB_REF" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::tag v${{ steps.version.outputs.version }} already exists — pick the next version" >&2
+            exit 1
+          fi
+
+      # Keep project.yml's MARKETING_VERSION in step with the release so
+      # source builds report the right version (docs/RELEASING.md). The tag
+      # is created later by the release itself, pointing at this commit.
+      - name: Bump project.yml on main
+        id: bump
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CURRENT=$(sed -n 's/^[[:space:]]*MARKETING_VERSION: //p' project.yml | tr -d '[:space:]')
+          if [ "$CURRENT" != "$VERSION" ]; then
+            sed -i '' "s/^\([[:space:]]*MARKETING_VERSION:\).*/\1 $VERSION/" project.yml
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add project.yml
+            git commit -m "release: bump MARKETING_VERSION to $VERSION"
+            git push origin HEAD:main
+          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install XcodeGen
         run: |
@@ -182,10 +227,15 @@ jobs:
             cp Scripts/first-launch-note.md release-note.md
           fi
 
+      # On a tag push the tag exists and target_commitish is ignored; on a
+      # manual publish the release creates the tag, pointed at the commit
+      # the bump step left main on.
       - name: Publish GitHub Release
-        if: github.event_name == 'push'
+        if: env.PUBLISHING == 'true'
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: v${{ steps.version.outputs.version }}
+          target_commitish: ${{ steps.bump.outputs.sha || github.sha }}
           files: Keelhaven-${{ steps.version.outputs.version }}.dmg
           body_path: release-note.md
           generate_release_notes: true
@@ -197,13 +247,13 @@ jobs:
       # step is skipped and the next release-local.sh run — or a manual
       # Scripts/update-homebrew-tap.sh — catches the tap up.
       - name: Bump Homebrew tap
-        if: github.event_name == 'push' && env.HAS_TAP_TOKEN == 'true'
+        if: env.PUBLISHING == 'true' && env.HAS_TAP_TOKEN == 'true'
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: ./Scripts/update-homebrew-tap.sh "${{ steps.version.outputs.version }}" "Keelhaven-${{ steps.version.outputs.version }}.dmg"
 
       - name: Upload DMG artifact
-        if: github.event_name == 'workflow_dispatch'
+        if: env.PUBLISHING != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: Keelhaven-${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Privacy-first Mac backup to your own storage. Free and open source (GPLv3) — n
 
 Keelhaven wraps the battle-tested [restic](https://restic.net) engine in a native SwiftUI menu bar app: pick folders, pick a destination you own (external drive, any S3-compatible bucket, or SFTP/NAS), set a schedule — your files are encrypted on your Mac before they leave it.
 
-**Status: public beta.** The engine, wizard, scheduled backups, and whole-snapshot restore all work; file-level browsing inside snapshots is next.
+**Status: public beta.** The engine, wizard, scheduled backups, whole-snapshot restore, and periodic repository verification all work; file-level browsing inside snapshots is next.
 
 ## Install
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,9 +2,9 @@
 
 `.github/workflows/release.yml` builds a universal `Keelhaven-<version>.dmg`
 and attaches it to a GitHub Release. It triggers on pushing a `vX.Y.Z` tag,
-or manually via Actions → Release → Run workflow (give it a version, it
-uploads the DMG as a build artifact instead of creating a release — useful
-for a dry run).
+or manually via Actions → Release → Run workflow: with **publish** ticked it
+cuts the whole release itself, without it just uploads the DMG as a build
+artifact — useful for a dry run.
 
 **No Apple Developer membership is required.** With no signing secrets
 configured (the current state), the app is ad-hoc signed and not notarized:
@@ -23,12 +23,22 @@ and two macOS builds per tag would pay the 10× premium twice.
 
 ## Cutting a release
 
-Whichever path you take, first bump `MARKETING_VERSION` in `project.yml` to
-the new version and land that on `main`. Both release paths override it from
-the tag at build time, so the released DMG is always right — but source
-builds (contributors, `make install`) report whatever `project.yml` says, and
-a stale value makes them nag themselves to "update" to the version they
+Whichever path you take, `MARKETING_VERSION` in `project.yml` must match the
+new version on `main` — the one-button path commits that bump for you, the
+other two need it landed first. Every release path overrides it from the tag
+at build time, so the released DMG is always right — but source builds
+(contributors, `make install`) report whatever `project.yml` says, and a
+stale value makes them nag themselves to "update" to the version they
 already have.
+
+### One button, from GitHub (recommended)
+
+Actions → Release → **Run workflow**: enter the version, tick **publish**.
+The run bumps `project.yml` on `main` if needed, builds the universal DMG,
+creates the `v<version>` tag and the GitHub Release, and bumps the
+[Homebrew tap](#homebrew-tap) when its secret is set. Guard rails: publish
+runs only from `main`, refuse an existing tag, refuse a malformed version.
+Left unticked, a manual run stays the artifact-only dry run.
 
 ### From this Mac (no Actions minutes needed)
 
@@ -55,14 +65,15 @@ gh workflow disable release.yml && gh workflow disable website.yml
 # later: gh workflow enable release.yml && gh workflow enable website.yml
 ```
 
-### Via GitHub Actions
+### Via a tag push
 
 ```bash
 git tag v0.2.0
 git push origin v0.2.0
 ```
 
-Watch the run under Actions → Release. On success:
+Watch the run under Actions → Release. On success (same for the one-button
+path):
 
 1. A GitHub Release for the tag appears with `Keelhaven-0.2.0.dmg` attached
    and first-launch instructions in the body (omitted once builds are
@@ -76,7 +87,7 @@ Watch the run under Actions → Release. On success:
 4. With the `HOMEBREW_TAP_TOKEN` secret configured, the workflow also bumps
    the [Homebrew tap](#homebrew-tap); without it that step is skipped.
 
-Either path ends in the same place, and they can be mixed freely: both the
+Every path ends in the same place, and they can be mixed freely: both the
 workflow and `deploy-site.sh` mirror whatever the *newest published release*
 is, so a later Actions deploy won't clobber a locally cut release or vice
 versa.

--- a/project.yml
+++ b/project.yml
@@ -53,7 +53,7 @@ targets:
         # this from the tag, but source builds report it as-is — a stale value
         # makes them nag themselves to "update" to the version they already
         # have (docs/RELEASING.md).
-        MARKETING_VERSION: 0.2.0
+        MARKETING_VERSION: 0.3.0
         CURRENT_PROJECT_VERSION: 1
         SWIFT_EMIT_LOC_STRINGS: YES
     postBuildScripts:

--- a/site/index.md
+++ b/site/index.md
@@ -222,7 +222,7 @@ For now, yes — every run adds a snapshot, and Keelhaven never deletes one. Sna
 </FaqItem>
 <FaqItem question="How do I know the backups are actually good?">
 
-A failed or incomplete run is never silent — errors from the engine surface immediately in the menu bar and as a notification. What Keelhaven doesn't do yet is periodically re-verify an existing repository; that's on the roadmap. Because the repository is standard restic, `restic check` gives you that today — and restoring a file now and then is the gold standard for any backup tool, ours included.
+A failed or incomplete run is never silent — errors from the engine surface immediately in the menu bar and as a notification. Keelhaven also verifies each plan's repository with restic's own integrity check on a schedule — weekly by default, adjustable per plan — and a quiet "Verified" line in the plan row shows the last time it passed; only a problem speaks up. And restoring a file now and then remains the gold standard for any backup tool, ours included.
 
 </FaqItem>
 <FaqItem question="Do I need to install anything else?">


### PR DESCRIPTION
Everything 0.3.0 needs before the tag. Reworked per review: **no CHANGELOG.md** — release notes stay exactly what they have always been (first-launch note + GitHub's auto-generated notes). `Scripts/release-local.sh` (`make release`) is untouched and remains the no-Actions fallback.

## One-button release

Actions → Release → **Run workflow** → version `0.3.0`, tick **publish**. The run does the whole series:

1. **Guards**: publish only from `main`, refuses an existing tag, refuses a malformed version.
2. **Bumps `project.yml`** on `main` if it doesn't already match (for 0.3.0 it will — bumped in this PR).
3. Builds the universal DMG (unchanged).
4. **Creates the `v<version>` tag + GitHub Release** (`tag_name`/`target_commitish`), which triggers `website.yml`'s DMG + `latest.json` mirror — race-proofed in #14, and v0.2.0 proved this event chain fires.
5. Bumps the Homebrew tap — still gated on the `HOMEBREW_TAP_TOKEN` secret, **which is not configured yet**; without it the cask stays at 0.1.0.

With **publish** unticked, a manual run keeps the old behavior exactly: dry-run build, DMG uploaded as an artifact, nothing public touched.

## 0.3.0 content flips

- `project.yml` → 0.3.0 (the site footer reads this at build time).
- README status line now lists periodic repository verification.
- Site FAQ answer flipped from "on the roadmap" to shipped.

## Verified

- `release.yml`: YAML parses, every multi-line step passes `bash -n`, step order checked.
- VitePress build passes with the FAQ change.

## ⚠️ Merge-then-release in one sitting

Merging deploys the site (FAQ + 0.3.0 footer) ahead of the release. Run the publish right after merging so the window where the site is ahead of the shipping build stays minutes, not days.