### PR TITLE
ci: dispatch the website mirror explicitly after publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: write
+      # To dispatch website.yml after publishing — see that step's comment.
+      actions: write
     # The secrets context is not available in step-level `if`s directly, so
     # surface "are the Apple credentials configured?" as job env instead.
     env:
@@ -239,6 +241,19 @@ jobs:
           files: Keelhaven-${{ steps.version.outputs.version }}.dmg
           body_path: release-note.md
           generate_release_notes: true
+
+      # The release above is created with GITHUB_TOKEN, and GitHub
+      # suppresses events made with a workflow's own token (anti-recursion),
+      # so website.yml's `release: published` trigger never fires from here
+      # — v0.3.0 shipped with a stale latest.json exactly this way. Dispatch
+      # the deploy explicitly instead: workflow_dispatch is exempt from the
+      # suppression, and the DMG is uploaded by now, so the mirror finds it
+      # on the first look.
+      - name: Deploy the website mirror
+        if: env.PUBLISHING == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run website.yml --ref main
 
       # Point the Homebrew tap (keelapps/homebrew-tap) at the DMG that was
       # just published, so `brew install --cask keelapps/tap/keelhaven`

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,9 +14,10 @@ on:
     paths:
       - site/**
       - .github/workflows/website.yml
-  # release.yml's tag-push path publishes a GitHub Release — this is the
-  # only trigger that fires right after one lands, so the mirror step below
-  # gets a chance to run before anyone notices the download is stale.
+  # Fires when a human publishes a release (say, a draft from the UI).
+  # A release published by release.yml does NOT land here — GitHub
+  # suppresses events created with a workflow's own token — which is why
+  # release.yml dispatches this workflow explicitly after publishing.
   release:
     types: [published]
   workflow_dispatch:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -78,7 +78,7 @@ path):
 1. A GitHub Release for the tag appears with `Keelhaven-0.2.0.dmg` attached
    and first-launch instructions in the body (omitted once builds are
    notarized).
-2. Publishing the release triggers `website.yml`, which mirrors the DMG to
+2. The run then dispatches `website.yml`, which mirrors the DMG to
    `https://keelhaven.app/downloads/` and writes `latest.json` next to it.
 3. `latest.json` lights up the rest on its own: the site's hero button
    switches from the early-access mailto to a real download link, and


### PR DESCRIPTION
Root cause of v0.3.0 shipping with a stale `latest.json`: **GitHub suppresses events created with a workflow's own token** (anti-recursion), so the release that `release.yml` publishes via `GITHUB_TOKEN` never fires `website.yml`'s `release: published` trigger.

v0.1.0 and v0.2.0 dodged this by accident: those releases were **drafts published by hand from the UI** (the run history shows the release-event runs with `actor=shenxianpeng`, and the v0.2.0 release timestamp *precedes* its release.yml run — the publish created the tag, not the other way round). Any fully automated path — one-button publish or a bare tag push — hits the suppression.

Fix: after publishing, `release.yml` now dispatches `website.yml` directly (`gh workflow run`, needs the new `actions: write` permission) — `workflow_dispatch` is explicitly exempt from the suppression, and by that point the DMG is fully uploaded so the mirror finds it on the first look. The `release:` trigger stays in `website.yml` for releases published by hand.

**Production is already healed manually**: I dispatched `website.yml` (run 33019509321) so `latest.json`/`downloads/` now serve 0.3.0, and bumped the Homebrew tap to 0.3.0 locally via `Scripts/update-homebrew-tap.sh`. This PR just makes the next release do both on its own — the tap step still needs a working `HOMEBREW_TAP_TOKEN` (see the note about the fine-grained PAT's resource owner in the review thread).