### PR TITLE
Add README badge row and X (Twitter) links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Downloads](https://img.shields.io/github/downloads/shenxianpeng/keelhaven/total)](https://github.com/shenxianpeng/keelhaven/releases)
 [![License](https://img.shields.io/github/license/shenxianpeng/keelhaven)](LICENSE)
 [![macOS 14+](https://img.shields.io/badge/macOS-14%2B-black?logo=apple)](https://keelhaven.app)
-[![Follow @xianpengshen on X](https://img.shields.io/twitter/follow/xianpengshen?label=follow&logo=x&color=black)](https://x.com/xianpengshen)
+[![Follow @xianpengshen on X](https://img.shields.io/twitter/follow/xianpengshen?style=social&logo=x)](https://x.com/xianpengshen)
 
 Privacy-first Mac backup to your own storage. Free and open source (GPLv3) — no subscription, no telemetry.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 
 **[keelhaven.app](https://keelhaven.app)**
 
-[![Follow @xianpengshen on X](https://img.shields.io/twitter/follow/xianpengshen?style=social&logo=x)](https://x.com/xianpengshen)
+[![CI](https://img.shields.io/github/actions/workflow/status/shenxianpeng/keelhaven/ci.yml?branch=main&label=CI&logo=github)](https://github.com/shenxianpeng/keelhaven/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/shenxianpeng/keelhaven)](https://github.com/shenxianpeng/keelhaven/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/shenxianpeng/keelhaven/total)](https://github.com/shenxianpeng/keelhaven/releases)
+[![License](https://img.shields.io/github/license/shenxianpeng/keelhaven)](LICENSE)
+[![macOS 14+](https://img.shields.io/badge/macOS-14%2B-black?logo=apple)](https://keelhaven.app)
+[![Follow @xianpengshen on X](https://img.shields.io/twitter/follow/xianpengshen?label=follow&logo=x&color=black)](https://x.com/xianpengshen)
 
 Privacy-first Mac backup to your own storage. Free and open source (GPLv3) — no subscription, no telemetry.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **[keelhaven.app](https://keelhaven.app)**
 
+[![Follow @xianpengshen on X](https://img.shields.io/twitter/follow/xianpengshen?style=social&logo=x)](https://x.com/xianpengshen)
+
 Privacy-first Mac backup to your own storage. Free and open source (GPLv3) — no subscription, no telemetry.
 
 Keelhaven wraps the battle-tested [restic](https://restic.net) engine in a native SwiftUI menu bar app: pick folders, pick a destination you own (external drive, any S3-compatible bucket, or SFTP/NAS), set a schedule — your files are encrypted on your Mac before they leave it.

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -98,6 +98,7 @@ export default defineConfig({
     // and footer carry the same link, driven by index.md frontmatter.
     socialLinks: [
       { icon: 'github', link: 'https://github.com/shenxianpeng/keelhaven' },
+      { icon: 'x', link: 'https://x.com/xianpengshen' },
     ],
     footer: {
       // The BSD-2-Clause notice travels with the app bundle (restic-LICENSE.txt

--- a/site/index.md
+++ b/site/index.md
@@ -29,6 +29,7 @@ landing:
         links:
           - { text: Email support, mailto: true }
           - { text: FAQ, anchor: faq }
+          - { text: Follow on X, href: "https://x.com/xianpengshen" }
       - title: Product
         links:
           - { text: Features, anchor: features }


### PR DESCRIPTION
Adds a badge row to the README and links to [@xianpengshen](https://x.com/xianpengshen) across the project:

- **README**: a flat-style shields.io badge row under the keelhaven.app link — CI status (`ci.yml` on main), latest release version, total release downloads, GPL-3.0 license, macOS 14+, and a follow badge for @xianpengshen
- **Landing page footer** (`site/index.md`): a "Follow on X" link in the Support group — rendered by `LandingFooter.vue`'s existing `href` handling, so it opens in a new tab like the GitHub link
- **Default-theme pages** (`/privacy`, `/licenses`): an X icon next to the GitHub icon via `themeConfig.socialLinks` in `config.mts`

All site additions are plain links — no embedded X widget or script — so the site still loads exactly one third party (Google Analytics) and `privacy.md` stays accurate as written.

Verified with a local `npm run build`: the links render in the landing footer and the default-theme navbar.