### PR TITLE
Lead the hero with the frictionless install command

### DIFF
--- a/Scripts/first-launch-note.md
+++ b/Scripts/first-launch-note.md
@@ -1,7 +1,9 @@
-Drag **Keelhaven** to Applications. This beta isn't notarized by Apple yet, so macOS asks you to allow it once on first launch:
+**Quickest install — no Gatekeeper prompt:**
 
-- **macOS 15 (Sequoia):** double-click the app, dismiss the warning, then open **System Settings › Privacy & Security**, scroll down, and click **Open Anyway**.
-- **macOS 14 (Sonoma):** right-click the app in Applications and choose **Open**, then **Open** again.
-- **Terminal instead:** `xattr -d com.apple.quarantine /Applications/Keelhaven.app`
+```
+brew install --cask shenxianpeng/tap/keelhaven
+```
 
-More detail: https://keelhaven.app/#faq
+No Homebrew? `curl -fsSL https://keelhaven.app/install.sh | bash` does the same.
+
+Or download the `.dmg` below and drag **Keelhaven** to Applications. This beta isn't notarized by Apple yet, so macOS asks you to allow it once on first launch — the [FAQ](https://keelhaven.app/#faq) has the three-click walkthrough.

--- a/site/.vitepress/theme/components/CommandBlock.vue
+++ b/site/.vitepress/theme/components/CommandBlock.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+// A click-to-copy command box. The whole box is the button, so a reader can
+// copy the install line without selecting it by hand; the label flips to a
+// confirmation for a moment. Used as the hero's primary CTA — during the
+// unnotarized beta the terminal install is the path with no Gatekeeper
+// prompt, so it leads.
+import { ref } from 'vue'
+
+const props = defineProps<{
+  command: string
+  note?: string
+  copyLabel?: string
+  copiedLabel?: string
+}>()
+
+const copied = ref(false)
+let timer: ReturnType<typeof setTimeout> | undefined
+
+const copy = async () => {
+  try {
+    await navigator.clipboard.writeText(props.command)
+    copied.value = true
+    clearTimeout(timer)
+    timer = setTimeout(() => (copied.value = false), 1600)
+  } catch {
+    // Clipboard blocked (insecure context, denied permission): the command
+    // is still visible and selectable, so there's nothing to recover — just
+    // don't flash the confirmation.
+  }
+}
+</script>
+
+<template>
+  <div class="kh-cmd">
+    <button
+      type="button"
+      class="kh-cmd-box"
+      :aria-label="`${copyLabel ?? 'Copy'}: ${command}`"
+      @click="copy"
+    >
+      <code>{{ command }}</code>
+      <span class="kh-cmd-copy" :class="{ 'is-copied': copied }">
+        {{ copied ? (copiedLabel ?? 'Copied') : (copyLabel ?? 'Copy') }}
+      </span>
+    </button>
+    <span v-if="note" class="kh-cmd-note">{{ note }}</span>
+  </div>
+</template>

--- a/site/.vitepress/theme/components/DownloadButton.vue
+++ b/site/.vitepress/theme/components/DownloadButton.vue
@@ -5,24 +5,28 @@
 // the manifest loads.
 import { useLatestRelease } from '../latest'
 
-defineProps<{
+const props = defineProps<{
   label: string
   fallbackHref: string
+  // Secondary styling for when it sits under a primary CTA (the hero's
+  // command box). Defaults to the filled primary look used elsewhere.
+  ghost?: boolean
 }>()
 
 const { dmgURL, version } = useLatestRelease()
+const btnClass = ['kh-btn', props.ghost ? 'kh-btn-ghost' : 'kh-btn-primary']
 </script>
 
 <template>
   <!-- `download` keeps VitePress's SPA router from intercepting the click:
        .dmg is not in its known-extensions list, so without it the router
        rewrites the href to …dmg.html and lands on the 404 page. -->
-  <a v-if="dmgURL" class="kh-btn kh-btn-primary" :href="dmgURL" download>
+  <a v-if="dmgURL" :class="btnClass" :href="dmgURL" download>
     {{ label }}<span v-if="version" class="kh-btn-version">v{{ version }}</span>
   </a>
   <a
     v-else
-    class="kh-btn kh-btn-primary"
+    :class="btnClass"
     :href="fallbackHref"
     target="_blank"
     rel="noopener"

--- a/site/.vitepress/theme/index.ts
+++ b/site/.vitepress/theme/index.ts
@@ -11,6 +11,7 @@ import MenuBarDemo from './components/MenuBarDemo.vue'
 import PricingCard from './components/PricingCard.vue'
 import FaqItem from './components/FaqItem.vue'
 import DownloadButton from './components/DownloadButton.vue'
+import CommandBlock from './components/CommandBlock.vue'
 import './landing.css'
 
 export default {
@@ -24,5 +25,6 @@ export default {
     app.component('PricingCard', PricingCard)
     app.component('FaqItem', FaqItem)
     app.component('DownloadButton', DownloadButton)
+    app.component('CommandBlock', CommandBlock)
   },
 } satisfies Theme

--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -323,27 +323,73 @@ body:has(.kh-landing) .VPLocalNav {
 }
 
 .kh-landing .kh-hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
   margin: 36px 0 0;
   padding-bottom: 24px;
   border-bottom: 1px solid var(--kh-line);
 }
 
-.kh-landing .kh-hero-install {
-  flex-basis: 100%;
+/* Copy-to-clipboard command box — the hero's primary CTA. */
+.kh-landing .kh-cmd {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.kh-landing .kh-cmd-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 560px;
+  padding: 13px 14px 13px 18px;
+  border: 1px solid var(--kh-line);
+  border-radius: 12px;
+  background: var(--kh-chip);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.kh-landing .kh-cmd-box:hover {
+  border-color: var(--kh-sea);
+}
+.kh-landing .kh-cmd-box code {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-size: 14.5px;
+  color: var(--kh-ink);
+}
+/* A leading $ sets the line as a terminal command without being copied. */
+.kh-landing .kh-cmd-box code::before {
+  content: '$ ';
+  color: var(--kh-sea);
+}
+.kh-landing .kh-cmd-copy {
+  flex-shrink: 0;
+  padding: 4px 11px;
+  border-radius: 999px;
+  background: var(--kh-paper);
+  border: 1px solid var(--kh-line);
+  font-size: 12.5px;
+  color: var(--kh-ink-soft);
+}
+.kh-landing .kh-cmd-copy.is-copied {
+  color: var(--kh-ink);
+  border-color: var(--kh-sea);
+}
+.kh-landing .kh-cmd-note {
   font-size: 13.5px;
   color: var(--kh-ink-soft);
 }
-.kh-landing .kh-hero-install code {
-  font-size: 12.5px;
-  padding: 3px 8px;
-  border-radius: 6px;
-  background: var(--kh-chip);
-  border: 1px solid var(--kh-line);
-  user-select: all;
+
+/* Secondary row under the command box: the .dmg download and guide link. */
+.kh-landing .kh-hero-alt {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0 0;
 }
 
 /* ---------- screenshot frame ---------- */

--- a/site/index.md
+++ b/site/index.md
@@ -69,11 +69,16 @@ const releases = computed(
     <span>No telemetry</span>
     <span>Restores with open tools</span>
   </p>
-  <p class="kh-hero-actions">
-    <DownloadButton label="Download for macOS" :fallback-href="releases" />
-    <a class="kh-btn kh-btn-ghost" href="#guide">Read the guide</a>
-    <span class="kh-hero-install">or from the terminal: <code>brew install --cask shenxianpeng/tap/keelhaven</code></span>
-  </p>
+  <div class="kh-hero-actions">
+    <CommandBlock
+      command="brew install --cask shenxianpeng/tap/keelhaven"
+      note="One command — installs and launches with no security prompt."
+    />
+    <p class="kh-hero-alt">
+      <DownloadButton label="Download the .dmg" :fallback-href="releases" ghost />
+      <a class="kh-btn kh-btn-ghost" href="#guide">Read the guide</a>
+    </p>
+  </div>
 </section>
 
 <LandingSection id="tour" eyebrow="00 · See it" title="One menu bar item. That's the whole app.">

--- a/site/zh/index.md
+++ b/site/zh/index.md
@@ -90,11 +90,18 @@ const releases = computed(
     <span>无遥测</span>
     <span>开源工具即可恢复</span>
   </p>
-  <p class="kh-hero-actions">
-    <DownloadButton label="下载 macOS 版" :fallback-href="releases" />
-    <a class="kh-btn kh-btn-ghost" href="#guide">先看指南</a>
-    <span class="kh-hero-install">或在终端安装：<code>brew install --cask shenxianpeng/tap/keelhaven</code></span>
-  </p>
+  <div class="kh-hero-actions">
+    <CommandBlock
+      command="brew install --cask shenxianpeng/tap/keelhaven"
+      note="一行命令，装完直接能开，不弹任何安全提示。"
+      copy-label="复制"
+      copied-label="已复制"
+    />
+    <p class="kh-hero-alt">
+      <DownloadButton label="下载 .dmg" :fallback-href="releases" ghost />
+      <a class="kh-btn kh-btn-ghost" href="#guide">先看指南</a>
+    </p>
+  </div>
 </section>
 
 <LandingSection id="tour" eyebrow="00 · 看一眼" title="一个菜单栏图标，就是整个应用。">


### PR DESCRIPTION
Follow-up to the Homebrew cask change (already pushed to the tap): the brew and curl install paths now clear the quarantine flag themselves, so they install and launch with **no Gatekeeper prompt**, while a downloaded `.dmg` still trips the warning. So the site and the release notes should lead with the path that's actually smooth during the unnotarized beta.

## Hero (both languages)

- **New `CommandBlock.vue`**: a click-to-copy command box (`$ brew install …`, Copy → Copied), now the hero's primary CTA. Strings localize through props (复制/已复制 on zh).
- The `.dmg` download drops to a **secondary ghost button** next to "Read the guide" — `DownloadButton` grows a `ghost` prop, keeps its live latest.json → direct-DMG behavior.
- A one-line note under the box: *"One command — installs and launches with no security prompt."* / 「一行命令，装完直接能开，不弹任何安全提示。」

## Release-note template (`Scripts/first-launch-note.md`)

Was a three-OS wall of Gatekeeper steps with no mention of what the release contained. Now opens with the one-line `brew install` (no prompt), the curl one-liner, then a single sentence sending `.dmg` users to the FAQ walkthrough. **Already applied to the published v0.4.0 release notes too** (the "What's Changed" list untouched, as requested).

## Also done outside this PR

- **Homebrew cask** (`shenxianpeng/homebrew-tap`): added a `postflight` that strips the quarantine flag (matching `install.sh`), removed the now-false "warns on first launch" caveat. Pushed directly to the tap; `brew style` clean, Ruby syntax OK. Live `brew install` verification was blocked in my sandbox — worth a manual `brew reinstall --cask shenxianpeng/tap/keelhaven` to confirm zero prompt.

## Verified

Built clean; headless screenshots at 1280px and 375px, both languages: command box fits the full command on desktop, scrolls on mobile, Copy interaction fires, secondary row and language switcher intact.

## Note on the tradeoff

Stripping quarantine removes Gatekeeper's check for brew/curl users — the same call `install.sh` already made. It's the honest beta tradeoff for an open-source, ad-hoc-signed app, and becomes moot the moment releases are notarized (then both the cask postflight and this messaging can revert).
