### PR TITLE
Recover from repository locks (restic unlock)

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -8,8 +8,13 @@ enum PlanRunState: Equatable {
     case running(progress: Double)
     case checking
     case pruning
+    case unlocking
     case succeeded(Date)
     case failed(String)
+    /// A failure restic blames on a repository lock (exit code 11). Separate
+    /// from `failed` for one reason: it is the only failure the row can offer
+    /// a fix for, so it carries an unlock button instead of dead red text.
+    case failedLocked(String)
 }
 
 /// Root observable state: owns the plan list, run states, and all services.
@@ -117,13 +122,18 @@ final class AppState {
         let states = runStates.values
         if states.contains(where: {
             switch $0 {
-            case .running, .checking, .pruning: return true
+            case .running, .checking, .pruning, .unlocking: return true
             default: return false
             }
         }) {
             return .symbol("arrow.triangle.2.circlepath")
         }
-        if states.contains(where: { if case .failed = $0 { return true }; return false }) {
+        if states.contains(where: {
+            switch $0 {
+            case .failed, .failedLocked: return true
+            default: return false
+            }
+        }) {
             return .symbol("exclamationmark.triangle")
         }
         return .idle
@@ -195,12 +205,12 @@ final class AppState {
     // MARK: - Running backups
 
     /// True while any plan has a restic process going — a backup, a
-    /// repository check, or a retention pass. One restic at a time, app-wide:
-    /// two invocations would contend for the repository lock.
+    /// repository check, a retention pass, or an unlock. One restic at a time,
+    /// app-wide: two invocations would contend for the repository lock.
     var isResticBusy: Bool {
         runStates.values.contains {
             switch $0 {
-            case .running, .checking, .pruning: return true
+            case .running, .checking, .pruning, .unlocking: return true
             default: return false
             }
         }
@@ -278,10 +288,13 @@ final class AppState {
                 await performPrune(current, binaryURL: binaryURL)
             }
         } catch {
-            let message = (error as? ResticError)?.localizedDescription ?? error.localizedDescription
+            let resticError = error as? ResticError
+            let message = resticError?.localizedDescription ?? error.localizedDescription
             let record = BackupRunRecord(date: startedAt, success: false, errorMessage: message)
             await finishRun(plan, record: record)
-            runStates[plan.id] = .failed(message)
+            runStates[plan.id] = resticError?.isRepositoryLocked == true
+                ? .failedLocked(message)
+                : .failed(message)
             await NotificationService.postBackupFailed(planName: plan.name, message: message)
         }
     }
@@ -352,6 +365,48 @@ final class AppState {
         try? await planStore.save(plans)
     }
 
+    // MARK: - Repository locks
+
+    /// Clears stale locks, then runs the backup they were blocking.
+    ///
+    /// Safe by construction: `restic unlock` (no `--remove-all`) removes only
+    /// locks whose owner is gone, so another Mac genuinely mid-backup keeps
+    /// its lock and its run. That also bounds what this can fix — against a
+    /// live lock it succeeds and changes nothing, and the plan stays blocked
+    /// until the other backup finishes, which is the correct outcome.
+    ///
+    /// The backup follows because clearing a lock is never the goal in
+    /// itself; it also re-runs the retention pass, which is what the lock was
+    /// really holding up.
+    func unlockRepository(_ plan: BackupPlan) {
+        guard !isResticBusy else { return }
+        guard let binaryURL = resticBinaryURL else {
+            runStates[plan.id] = .failed(ResticError.binaryNotFound.localizedDescription)
+            return
+        }
+        runStates[plan.id] = .unlocking
+        Task {
+            do {
+                let credentials = try credentials(for: plan)
+                let runner = ResticRunner(binaryURL: binaryURL)
+                try await runner.runIgnoringOutput(
+                    .unlock,
+                    destination: plan.destination,
+                    credentials: credentials
+                )
+                runStates[plan.id] = .idle
+                runBackup(plan)
+            } catch {
+                let resticError = error as? ResticError
+                let message = resticError?.localizedDescription ?? error.localizedDescription
+                // A lock that survives its own removal is not something the
+                // button can fix twice — fall back to plain `failed` so the
+                // row stops offering the same dead end.
+                runStates[plan.id] = .failed(message)
+            }
+        }
+    }
+
     // MARK: - Retention
 
     /// Scheduled-only, chained off `performBackup` like checks — there is no
@@ -377,17 +432,27 @@ final class AppState {
             runStates[plan.id] = stateBefore
             // Success is silent — space quietly reclaimed is the feature.
         } catch {
-            let message = (error as? ResticError)?.localizedDescription ?? error.localizedDescription
+            let resticError = error as? ResticError
+            let message = resticError?.localizedDescription ?? error.localizedDescription
+            let blockedByLock = resticError?.isRepositoryLocked == true
             await finishPrune(plan, record: PruneRunRecord(
                 date: startedAt,
                 success: false,
                 duration: Date().timeIntervalSince(startedAt),
-                errorMessage: message
+                errorMessage: message,
+                blockedByLock: blockedByLock
             ))
             // Unlike a failed check, a failed prune keeps `stateBefore`: the
             // backups themselves are intact, only the cleanup is late — the
             // notification carries the details and the clock retries in a
             // week.
+            //
+            // A lock is the exception, and the reason `blockedByLock` exists.
+            // `forget --prune` needs an exclusive lock, so one stale lock
+            // blocks it every week from here on while backups keep succeeding
+            // — a plan that looks healthy and quietly never reclaims a byte.
+            // The row surfaces that one and offers the unlock; retrying on a
+            // weekly timer would never have cleared it.
             runStates[plan.id] = stateBefore
             await NotificationService.postPruneFailed(planName: plan.name, message: message)
         }

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -334,6 +334,16 @@
         }
       }
     },
+    "Backup blocked by a repository lock": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份被仓库的锁挡住了"
+          }
+        }
+      }
+    },
     "Backup cleanup failed": {
       "localizations": {
         "zh-Hans": {
@@ -510,6 +520,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在清理旧快照…"
+          }
+        }
+      }
+    },
+    "Cleanup blocked by a repository lock": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理被仓库的锁挡住了"
           }
         }
       }
@@ -1737,6 +1757,16 @@
         }
       }
     },
+    "The last retention pass could not get a lock on the repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上一次保留策略清理没能获得仓库的锁"
+          }
+        }
+      }
+    },
     "Thins older snapshots to daily, weekly and monthly keepers and reclaims the space — after a backup, at most once a week. Keep everything never deletes a snapshot.": {
       "localizations": {
         "zh-Hans": {
@@ -1757,6 +1787,16 @@
         }
       }
     },
+    "This clears locks left behind by a backup that was interrupted — the usual reason cleanup keeps failing. A backup running right now on another Mac keeps its own lock and is left alone; that one has to finish on its own.\n\nKeelhaven retries this plan's backup right after unlocking.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这会清除被中断的备份留下的锁 —— 清理反复失败通常就是这个原因。如果此刻另一台 Mac 正在备份，它的锁不受影响，那次备份得由它自己跑完。\n\n解锁后 Keelhaven 会立即重试这个计划的备份。"
+          }
+        }
+      }
+    },
     "This folder already contains a backup repository. Connect to it under Advanced options, or choose an empty folder.": {
       "localizations": {
         "zh-Hans": {
@@ -1773,6 +1813,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "改为自己输入"
+          }
+        }
+      }
+    },
+    "Unlock": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁"
+          }
+        }
+      }
+    },
+    "Unlock Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁仓库…"
+          }
+        }
+      }
+    },
+    "Unlock the repository for “%@”?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要解锁“%@”的仓库吗？"
+          }
+        }
+      }
+    },
+    "Unlocking repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解锁仓库"
+          }
+        }
+      }
+    },
+    "Unlocking repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解锁仓库…"
+          }
+        }
+      }
+    },
+    "Unlock…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁…"
           }
         }
       }

--- a/Keelhaven/MenuBar/PlanHealth.swift
+++ b/Keelhaven/MenuBar/PlanHealth.swift
@@ -13,9 +13,9 @@ enum PlanHealth {
 extension BackupPlan {
     func health(runState: PlanRunState) -> PlanHealth {
         switch runState {
-        case .running, .checking, .pruning:
+        case .running, .checking, .pruning, .unlocking:
             return .running
-        case .failed:
+        case .failed, .failedLocked:
             return .needsAttention
         case .succeeded:
             return .ok

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -89,6 +89,15 @@ struct PlanStatusRow: View {
                 if let lastCheck = plan.lastCheck {
                     verificationLine(lastCheck)
                 }
+                // A lock-blocked cleanup is the one failure that never clears
+                // itself and never shows up anywhere else: backups keep
+                // succeeding, the dot stays green, and the weekly retry hits
+                // the same lock forever. Its own line, with the way out.
+                if let lastPrune = plan.lastPrune,
+                   !lastPrune.success,
+                   lastPrune.blockedByLock == true {
+                    retentionBlockedLine(lastPrune)
+                }
                 statusLine
             }
         }
@@ -122,6 +131,14 @@ struct PlanStatusRow: View {
         }
         Button("Verify Backup Now") {
             appState.runCheck(plan)
+        }
+        .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
+        // Also reachable from the failed row itself. It stays in the menu for
+        // the case the row can't cover: a relaunch resets the run state to
+        // idle, so a plan still locked from yesterday shows only red text
+        // until its next scheduled attempt re-detects the lock.
+        Button("Unlock Repository…") {
+            confirmAndUnlock()
         }
         .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
         Button("Edit Plan…") {
@@ -172,6 +189,22 @@ struct PlanStatusRow: View {
         alert.addButton(withTitle: String(localized: "Cancel"))
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         deletePlan()
+    }
+
+    /// No Touch ID gate and no warning styling: this destroys no backup data,
+    /// and `restic unlock` leaves a lock another Mac is actively holding
+    /// alone. It still asks first, because it is worth saying what it does
+    /// and does not reach.
+    private func confirmAndUnlock() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Unlock the repository for “\(plan.name)”?")
+        alert.informativeText = String(localized: "This clears locks left behind by a backup that was interrupted — the usual reason cleanup keeps failing. A backup running right now on another Mac keeps its own lock and is left alone; that one has to finish on its own.\n\nKeelhaven retries this plan's backup right after unlocking.")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "Unlock"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        appState.unlockRepository(plan)
     }
 
     /// Both actions below are gated behind Touch ID (login password fallback
@@ -237,6 +270,23 @@ struct PlanStatusRow: View {
             : String(localized: "Backup verification failed"))
     }
 
+    /// Orange, not red: the backups themselves are fine and the health dot
+    /// stays green — it is only the space reclaim that is stuck.
+    private func retentionBlockedLine(_ prune: PruneRunRecord) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "clock.badge.exclamationmark")
+            Text("Cleanup blocked by a repository lock")
+            Button("Unlock…") {
+                confirmAndUnlock()
+            }
+            .buttonStyle(.link)
+            .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
+        }
+        .font(.callout)
+        .foregroundStyle(.orange)
+        .help(prune.errorMessage ?? String(localized: "The last retention pass could not get a lock on the repository"))
+    }
+
     @ViewBuilder
     private var statusLine: some View {
         switch runState {
@@ -265,11 +315,37 @@ struct PlanStatusRow: View {
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(localized: "Retention cleanup running"))
+        case .unlocking:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Unlocking repository…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "Unlocking repository"))
         case .failed(let message):
             Text(message)
                 .font(.callout)
                 .foregroundStyle(.red)
                 .help(message)
+        case .failedLocked(let message):
+            // restic's own three lines of PID-and-hostname detail stay in the
+            // tooltip; the row says the one thing that matters and offers the
+            // way out, which is the whole point of splitting this state off.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Backup blocked by a repository lock")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                Button("Unlock…") {
+                    confirmAndUnlock()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(appState.isResticBusy || appState.resticBinaryURL == nil)
+            }
+            .help(message)
         case .succeeded(let date):
             RelativeTimeText(kind: .backedUp, date: date)
                 .font(.callout)

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/PruneRunRecord.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/PruneRunRecord.swift
@@ -7,16 +7,25 @@ public struct PruneRunRecord: Codable, Hashable, Sendable {
     public var success: Bool
     public var duration: TimeInterval?
     public var errorMessage: String?
+    /// Set when the pass failed because the repository was locked — the one
+    /// prune failure that never clears itself. `forget --prune` needs an
+    /// exclusive lock, so a lock left behind by an interrupted run blocks it
+    /// forever, while plain backups carry on unaffected (they share a
+    /// non-exclusive lock). Optional so plans written before this field
+    /// decode unchanged.
+    public var blockedByLock: Bool?
 
     public init(
         date: Date,
         success: Bool,
         duration: TimeInterval? = nil,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        blockedByLock: Bool? = nil
     ) {
         self.date = date
         self.success = success
         self.duration = duration
         self.errorMessage = errorMessage
+        self.blockedByLock = blockedByLock
     }
 }

--- a/KeelhavenCore/Sources/KeelhavenCore/Resources/Localizable.xcstrings
+++ b/KeelhavenCore/Sources/KeelhavenCore/Resources/Localizable.xcstrings
@@ -2,9 +2,9 @@
   "sourceLanguage" : "en",
   "version" : "1.0",
   "strings" : {
-    "The restic command-line tool could not be found. Install it with: brew install restic" : {
+    "Keelhaven's backup engine is missing from the app. Reinstalling Keelhaven from keelhaven.app restores it." : {
       "localizations" : {
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "找不到 restic 备份引擎。请用以下命令安装：brew install restic" } }
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Keelhaven 的备份引擎不在应用里了。从 keelhaven.app 重新安装 Keelhaven 即可恢复。" } }
       }
     },
     "The backup repository was not found. %@" : {

--- a/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticCommand.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticCommand.swift
@@ -18,6 +18,15 @@ public enum ResticCommand: Equatable, Sendable {
     case catConfig
     /// Restores a whole snapshot into the target folder.
     case restore(snapshotID: String, target: String)
+    /// Clears stale locks so retention passes can run again.
+    ///
+    /// Deliberately without `--remove-all`. Verified against restic 0.19.1:
+    /// the plain command removes only locks whose owning process is gone,
+    /// and leaves a lock another machine is actively holding exactly where it
+    /// is — so it can never cut short a backup running elsewhere against the
+    /// same repository. `--remove-all` does tear those out, which is why it
+    /// stays out of the app entirely.
+    case unlock
 
     public var arguments: [String] {
         switch self {
@@ -47,6 +56,8 @@ public enum ResticCommand: Equatable, Sendable {
             return ["cat", "config", "--json"]
         case .restore(let snapshotID, let target):
             return ["restore", snapshotID, "--target", target, "--json"]
+        case .unlock:
+            return ["unlock"]
         }
     }
 }

--- a/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticError.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticError.swift
@@ -3,8 +3,9 @@ import Foundation
 /// Typed failures from the restic layer.
 ///
 /// Exit codes verified against restic 0.19.1 (see Tests/…/Fixtures):
-///   10 = repository does not exist, 12 = wrong password.
-///   11 (lock) is documented by restic but not reproduced in fixtures.
+///   10 = repository does not exist, 12 = wrong password,
+///   11 = repository already locked (reproduced end to end in
+///   ResticRunnerIntegrationTests, which races two real restic processes).
 public enum ResticError: Error, Equatable, Sendable {
     case binaryNotFound
     case repositoryDoesNotExist(message: String)
@@ -13,6 +14,16 @@ public enum ResticError: Error, Equatable, Sendable {
     case wrongPassword(message: String)
     case commandFailed(exitCode: Int, message: String)
     case outputDecodingFailed(message: String)
+
+    /// True for the one failure the app can offer a way out of. Two things
+    /// produce it: a stale lock from an interrupted run, which `unlock`
+    /// clears, and a live lock from another machine backing up to the same
+    /// repository, which simply needs waiting out. Everything else needs the
+    /// user to change something.
+    public var isRepositoryLocked: Bool {
+        if case .repositoryLocked = self { return true }
+        return false
+    }
 
     public static func classify(exitCode: Int32, stderr: String) -> ResticError {
         // restic ≥0.17 writes a {"message_type":"exit_error","code":…,"message":…}
@@ -55,7 +66,7 @@ extension ResticError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .binaryNotFound:
-            return String(localized: "The restic command-line tool could not be found. Install it with: brew install restic", bundle: .module)
+            return String(localized: "Keelhaven's backup engine is missing from the app. Reinstalling Keelhaven from keelhaven.app restores it.", bundle: .module)
         case .repositoryDoesNotExist(let message):
             return String(localized: "The backup repository was not found. \(message)", bundle: .module)
         case .repositoryAlreadyExists:

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/EdgeCaseTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/EdgeCaseTests.swift
@@ -7,9 +7,27 @@ final class ResticErrorDescriptionTests: XCTestCase {
         XCTAssertEqual(error, .repositoryLocked(message: "repo already locked"))
     }
 
+    /// The lock is the only failure the app offers a fix for, so every other
+    /// case must stay out of that branch — a stray true would put an unlock
+    /// button on a failure unlocking cannot help.
+    func testOnlyRepositoryLockedIsUnlockable() {
+        XCTAssertTrue(ResticError.repositoryLocked(message: "m").isRepositoryLocked)
+        let others: [ResticError] = [
+            .binaryNotFound,
+            .repositoryDoesNotExist(message: "m"),
+            .repositoryAlreadyExists(message: "m"),
+            .wrongPassword(message: "m"),
+            .commandFailed(exitCode: 3, message: "m"),
+            .outputDecodingFailed(message: "m"),
+        ]
+        for error in others {
+            XCTAssertFalse(error.isRepositoryLocked, "\(error) must not offer unlock")
+        }
+    }
+
     func testEveryCaseHasAnActionableDescription() {
         let cases: [(ResticError, String)] = [
-            (.binaryNotFound, "could not be found"),
+            (.binaryNotFound, "backup engine is missing"),
             (.repositoryDoesNotExist(message: "m"), "was not found"),
             (.repositoryAlreadyExists(message: "m"), "already contains a backup repository"),
             (.repositoryLocked(message: "m"), "locked by another process"),

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -88,10 +88,38 @@ final class ModelRoundTripTests: XCTestCase {
                 date: date,
                 success: false,
                 duration: 42.0,
-                errorMessage: "unable to create lock in backend"
+                errorMessage: "unable to create lock in backend",
+                blockedByLock: true
             )
         )
         XCTAssertEqual(try roundTrip(plan), plan)
+        XCTAssertEqual(try roundTrip(plan).lastPrune?.blockedByLock, true)
+    }
+
+    /// A plan saved before `blockedByLock` existed must decode with it nil —
+    /// not false — so the row can tell "no lock problem" from "never checked".
+    func testPruneRecordWithoutLockFlagDecodesAsUnknown() throws {
+        let record = PruneRunRecord(
+            date: date,
+            success: false,
+            errorMessage: "something else went wrong"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoder.encode(record)) as? [String: Any]
+        )
+        XCTAssertNil(object["blockedByLock"], "nil must not be encoded at all")
+        object.removeValue(forKey: "blockedByLock")
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            PruneRunRecord.self,
+            from: try JSONSerialization.data(withJSONObject: object)
+        )
+        XCTAssertNil(decoded.blockedByLock)
+        XCTAssertEqual(decoded, record)
     }
 
     func testLegacyPlanJSONDecodesWithFeatureDefaults() throws {

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
@@ -26,6 +26,13 @@ final class ResticCommandTests: XCTestCase {
         XCTAssertEqual(command.arguments, ["backup", "--json", "/tmp/data"])
     }
 
+    /// No `--remove-all`: that would also drop the exclusive locks
+    /// `forget --prune` holds, turning a recovery into a way to corrupt a
+    /// concurrent repack.
+    func testUnlockArguments() {
+        XCTAssertEqual(ResticCommand.unlock.arguments, ["unlock"])
+    }
+
     func testCatConfigArguments() {
         XCTAssertEqual(ResticCommand.catConfig.arguments, ["cat", "config", "--json"])
     }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -159,6 +159,129 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         }
     }
 
+    /// The lock path, end to end against a real restic — the exact failure
+    /// the menu bar's unlock button exists for.
+    ///
+    /// A backup killed outright (power cut, force quit) leaves its
+    /// non-exclusive lock behind. Plain backups step around it, so the plan
+    /// keeps looking healthy; `forget --prune` cannot, because it needs an
+    /// exclusive lock, so retention fails with exit code 11 every week from
+    /// then on and never reclaims a byte. `unlock` is what clears it.
+    ///
+    /// The lock is held by `backup --stdin` reading a pipe nothing writes to:
+    /// it takes the lock immediately and holds it until EOF, so SIGKILL lands
+    /// while the lock is definitely there. Backing up real files would race —
+    /// it finishes, and releases the lock, before the kill.
+    func testStaleLockBlocksPruneUntilUnlockClearsIt() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let repoURL = workDirectory.appendingPathComponent("repo", isDirectory: true)
+        let sourceURL = workDirectory.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+        try Data("lock test\n".utf8).write(to: sourceURL.appendingPathComponent("a.txt"))
+
+        let destination = Destination.local(path: repoURL.path)
+        let credentials = RepoCredentials(repositoryPassword: "lock-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+        // A snapshot, so the retention pass below has something real to do.
+        for try await _ in runner.backupStream(
+            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test"),
+            destination: destination,
+            credentials: credentials
+        ) {}
+
+        let holder = Process()
+        holder.executableURL = binary
+        holder.arguments = ["backup", "--stdin", "--stdin-filename", "held.txt"]
+        holder.environment = [
+            "RESTIC_REPOSITORY": repoURL.path,
+            "RESTIC_PASSWORD": credentials.repositoryPassword,
+            "PATH": "/usr/bin:/bin",
+            "HOME": NSHomeDirectory(),
+            "TMPDIR": NSTemporaryDirectory(),
+        ]
+        let holderInput = Pipe()
+        holder.standardInput = holderInput
+        holder.standardOutput = FileHandle.nullDevice
+        holder.standardError = FileHandle.nullDevice
+        try holder.run()
+        defer {
+            try? holderInput.fileHandleForWriting.close()
+            if holder.isRunning {
+                holder.terminate()
+                holder.waitUntilExit()
+            }
+        }
+
+        let locksURL = repoURL.appendingPathComponent("locks", isDirectory: true)
+        func lockCount() -> Int {
+            ((try? FileManager.default.contentsOfDirectory(atPath: locksURL.path)) ?? []).count
+        }
+        var lockAppeared = false
+        for _ in 0..<100 where !lockAppeared {
+            if lockCount() == 0 {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            } else {
+                lockAppeared = true
+            }
+        }
+        guard lockAppeared else {
+            return XCTFail("The holder process never took a lock — test setup is broken")
+        }
+
+        // SIGKILL, not terminate: restic handles SIGTERM by releasing the
+        // lock, which is precisely the case that needs no recovery.
+        kill(holder.processIdentifier, SIGKILL)
+        holder.waitUntilExit()
+        XCTAssertEqual(lockCount(), 1, "SIGKILL should have left the lock behind")
+
+        // Backups are unaffected — the reason this failure hides so well.
+        for try await _ in runner.backupStream(
+            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test"),
+            destination: destination,
+            credentials: credentials
+        ) {}
+
+        // Retention is not: exclusive lock, so exit code 11.
+        do {
+            try await runner.runIgnoringOutput(
+                .forget(retention: .year),
+                destination: destination,
+                credentials: credentials
+            )
+            XCTFail("Expected the stale lock to block forget --prune")
+        } catch let error as ResticError {
+            guard case .repositoryLocked = error else {
+                return XCTFail("Expected repositoryLocked, got \(error)")
+            }
+            XCTAssertTrue(error.isRepositoryLocked)
+        }
+
+        // The way out the unlock button takes.
+        try await runner.runIgnoringOutput(
+            .unlock,
+            destination: destination,
+            credentials: credentials
+        )
+        XCTAssertEqual(lockCount(), 0, "unlock left the stale lock behind")
+
+        // Same command, now unblocked — the recovery actually recovers.
+        try await runner.runIgnoringOutput(
+            .forget(retention: .year),
+            destination: destination,
+            credentials: credentials
+        )
+    }
+
     func testMissingBinaryThrowsBinaryNotFound() async {
         let runner = ResticRunner(binaryURL: URL(fileURLWithPath: "/nonexistent/restic"))
         do {


### PR DESCRIPTION
A stale restic lock never clears itself, and the app had no way to remove one. restic's own error message tells you to run `unlock` — the CLI Keelhaven users deliberately don't have.

## The two failures

Both verified end to end against restic 0.19.1, not read off the docs:

| after a SIGKILL during… | lock left | `backup` | `forget --prune` | plain `unlock` |
|---|---|---|---|---|
| a backup | non-exclusive | ✅ steps around it | ❌ exit 11 | ✅ clears it |
| a retention pass | exclusive | ❌ exit 11 | ❌ exit 11 | ✅ clears it |
| *(another Mac backing up)* | *live* | ❌ exit 11 | ❌ exit 11 | no-op, by design |

The first row is the nasty one: backups keep succeeding and the health dot stays green, while retention fails with exit code 11 every week from then on and never reclaims a byte. The second stops that plan's backups for good — and since prune runs on the tail of a successful backup, quitting the app during cleanup is enough to cause it.

## Why plain `unlock`, never `--remove-all`

Plain `unlock` removes only locks whose owner is gone and leaves a lock another Mac is actively holding exactly where it is, so it can never cut a concurrent backup short. That bounds what the button can fix — against a live lock it succeeds and changes nothing, and the plan stays blocked until the other backup finishes, which is the correct outcome. `--remove-all` does tear live locks out, and stays out of the app entirely.

## What the user sees

- **Lock-blocked backup** → red status line plus an `Unlock…` button.
- **Lock-blocked cleanup** → an orange line of its own. It reads off the new `PruneRunRecord.blockedByLock`, so it survives a relaunch, and the health dot stays green because the backups genuinely are fine.
- **Menu item** as a catch-all, for the case a relaunch resets the run state before the next scheduled attempt re-detects the lock.
- Confirmation dialog is informational, not a warning: this destroys no backup data, and it says plainly what it does and does not reach.

Also fixes `ResticError.binaryNotFound`, which told users to `brew install restic` even though the engine ships inside the app bundle — the one moment that message appears is the one moment it must not send them somewhere wrong.

## Tests

`testStaleLockBlocksPruneUntilUnlockClearsIt` plays the whole story against a real restic: hold a lock with `backup --stdin` on a pipe nothing writes to, SIGKILL it, confirm backups still pass while `forget --prune` gets exit code 11, unlock, confirm prune then succeeds. (`backup --stdin` because backing up real files races — it finishes and releases the lock before the kill.) Exit code 11 was previously noted in `ResticError` as documented-but-unreproduced; it is now pinned down.

112 tests green, KeelhavenCore still at 100% line coverage, app builds.