### PR TITLE
Remote latency benchmark for restic ls (make bench-remote)

### DIFF
--- a/.github/workflows/bench-remote.yml
+++ b/.github/workflows/bench-remote.yml
@@ -1,0 +1,81 @@
+name: Remote backend benchmark
+
+# Manual only, deliberately. This measures `restic ls` against S3 and SFTP at
+# injected round-trip times — useful when a design decision hangs on it, not
+# on every PR:
+#   - macOS runners bill at 10× (see ci.yml; the quota ran dry once), and a
+#     full matrix is minutes of wall clock
+#   - shared runners have noisy CPU and disk, so absolute times wobble between
+#     runs; a flaky number gating a PR would be worse than no number at all
+#
+# The numbers that matter are the *ratios* — SFTP against S3, one-level
+# against full, warm cache against cold — and those hold up across runs.
+#
+# Scripts/bench-remote-ls.sh does the real work and runs the same way on a
+# laptop (`make bench-remote`), which is usually the faster way to get an
+# answer. This workflow exists for a clean-room second opinion.
+on:
+  workflow_dispatch:
+    inputs:
+      files:
+        description: Files in the synthetic dataset
+        default: "15000"
+        required: false
+      rtts:
+        description: Round-trip times to measure, milliseconds, space-separated
+        default: "0 20 60"
+        required: false
+      backends:
+        description: Backends to measure
+        default: "s3 sftp"
+        required: false
+      no_cache:
+        description: Also measure with restic's cache disabled (slow — minutes)
+        type: boolean
+        default: false
+        required: false
+
+concurrency:
+  group: bench-remote-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: restic ls latency
+    runs-on: macos-15
+    # A wedged backend would otherwise burn to the 6-hour default, which on a
+    # 10× runner is 3600 billed minutes.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install restic
+        # untap: the runner image ships an untrusted aws/tap that makes every
+        # brew command print tap-trust warnings; we don't use it.
+        run: |
+          brew untap aws/tap || true
+          brew install restic
+      - name: Run benchmark
+        env:
+          BENCH_FILES: ${{ inputs.files }}
+          BENCH_RTTS: ${{ inputs.rtts }}
+          BENCH_BACKENDS: ${{ inputs.backends }}
+          BENCH_NO_CACHE: ${{ inputs.no_cache && '1' || '0' }}
+        run: |
+          set -o pipefail
+          ./Scripts/bench-remote-ls.sh 2>&1 | tee "$RUNNER_TEMP/bench.txt"
+      - name: Publish results to the run summary
+        if: always()
+        run: |
+          {
+            echo "## restic ls latency"
+            echo
+            echo "restic: \`$(restic version)\`"
+            echo "dataset: ${{ inputs.files }} files · rtts: ${{ inputs.rtts }} ms"
+            echo
+            echo '```'
+            # Strip the bold escape sequences the script prints for terminals.
+            sed $'s/\033\\[[0-9;]*m//g' "$RUNNER_TEMP/bench.txt"
+            echo '```'
+            echo
+            echo "> Absolute times move with runner load; read the ratios."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,29 @@ Both suites honor `KEELHAVEN_TEST_S3_*` / `KEELHAVEN_TEST_SFTP_*` environment
 overrides for pointing at real cloud storage or a NAS — see the test file
 headers.
 
+### Remote latency benchmark
+
+Those suites prove the backends *work*; they say nothing about how they feel
+over a real network, because on loopback S3 and SFTP are indistinguishable
+from a local disk. `make bench-remote` measures that: it stands up its own
+MinIO and a throwaway sshd, puts `Scripts/netdelay.py` in front of them to
+inject a round trip in both directions, and times `restic ls`.
+
+```bash
+make bench-remote                                    # 15k files, 0/20/60 ms
+BENCH_FILES=2000 BENCH_RTTS="0 100" make bench-remote # quick, or a slow link
+```
+
+Everything is unprivileged and self-cleaning — your Remote Login setting is
+never touched, and the servers and temp data go away on exit. The same script
+runs in CI via the manual **Remote backend benchmark** workflow when you want
+a second opinion from a clean machine.
+
+Worth re-running when bumping the pinned restic version, when changing how
+the app calls restic, or before committing to a design that invokes restic
+more than once per user action — connection setup is the dominant cost on
+SFTP, and it is paid per invocation.
+
 ### Manual smoke test
 
 1. Run the app — it appears in the menu bar only (no Dock icon).

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: help bootstrap test restic build dmg release install update dev-site deploy-site clean
+.PHONY: help bootstrap test bench-remote restic build dmg release install update dev-site deploy-site clean
 
 help: ## List available targets
 	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "  make %-12s %s\n", $$1, $$2}'
@@ -13,6 +13,9 @@ bootstrap: ## Install development dependencies via Homebrew
 
 test: ## Run KeelhavenCore tests (incl. the real-restic integration suite)
 	swift test --package-path KeelhavenCore
+
+bench-remote: ## Measure restic ls latency against S3/SFTP at injected round trips
+	./Scripts/bench-remote-ls.sh
 
 restic: ## Vendor the universal restic binary that gets bundled into the app
 	./Scripts/fetch-restic.sh

--- a/Scripts/bench-remote-ls.sh
+++ b/Scripts/bench-remote-ls.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# Measures how long `restic ls` takes against remote backends at realistic
+# round-trip times — the numbers that decide how snapshot browsing must be
+# built.
+#
+# Why this exists: on loopback, S3 and SFTP look identical to a local disk
+# (~0.8s either way), so a laptop benchmark says nothing about a user whose
+# repository lives in a cloud bucket or on a NAS across a VPN. This script
+# puts a real backend behind Scripts/netdelay.py, which holds every byte for
+# half the round trip in each direction, and measures through it.
+#
+# Everything runs unprivileged and self-contained: MinIO is downloaded if
+# absent, sshd is a throwaway instance on a high port with its own host key
+# (your system Remote Login setting is never touched), and all state lives in
+# a temp directory that is removed on exit.
+#
+# Re-run it when:
+#   - bumping the pinned restic version (its backend behaviour can change)
+#   - changing how snapshot browsing calls restic
+#   - considering any design that calls restic more than once per user action
+#
+# Usage: bench-remote-ls.sh
+# Env:
+#   BENCH_FILES=15000        files in the synthetic dataset
+#   BENCH_RTTS="0 20 60"     round trips to measure, in milliseconds
+#   BENCH_BACKENDS="s3 sftp" which backends to run
+#   BENCH_NO_CACHE=1         also measure with restic's cache disabled
+#                            (slow — minutes — but shows what cache is worth)
+set -euo pipefail
+
+FILES="${BENCH_FILES:-15000}"
+RTTS="${BENCH_RTTS:-0 20 60}"
+BACKENDS="${BENCH_BACKENDS:-s3 sftp}"
+NO_CACHE="${BENCH_NO_CACHE:-0}"
+
+# High ports, away from anything a dev machine is likely to be running.
+MINIO_PORT=9400
+SSHD_PORT=2400
+# Each RTT gets its own proxy: MinIO at 94xx, sshd at 24xx.
+proxy_port() { # backend, index
+    if [ "$1" = s3 ]; then echo $((9410 + $2)); else echo $((2410 + $2)); fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+PIDS=()
+
+cleanup() {
+    for pid in ${PIDS+"${PIDS[@]}"}; do kill "$pid" 2>/dev/null || true; done
+    wait 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+say() { printf '\033[1m%s\033[0m\n' "$*"; }
+now() { python3 -c 'import time; print(time.time())'; }
+elapsed() { python3 -c "print(f'{($2-$1):6.2f}')"; }
+
+command -v restic >/dev/null || { echo "restic not found — brew install restic" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 1; }
+
+# ---------------------------------------------------------------- dataset
+
+say "Building a ${FILES}-file dataset"
+python3 - "$WORK/src" "$FILES" <<'PY'
+import os, sys
+root, count = sys.argv[1], int(sys.argv[2])
+# Fan out over nested directories so the tree has real depth, the way a
+# Documents or source folder does — a flat directory would understate the
+# number of tree objects restic has to walk.
+for i in range(count):
+    d = os.path.join(root, f"dir{i // 100:03d}", f"sub{i // 10 % 10}")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, f"file{i:05d}.txt"), "w") as f:
+        f.write(f"keelhaven benchmark payload {i}\n" * 8)
+PY
+
+# ---------------------------------------------------------------- backends
+
+start_minio() {
+    local minio_bin
+    if command -v minio >/dev/null; then
+        minio_bin="$(command -v minio)"
+    else
+        say "Downloading MinIO"
+        local arch os
+        arch="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
+        os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        curl -fsSL -o "$WORK/minio" "https://dl.min.io/server/minio/release/${os}-${arch}/minio"
+        chmod +x "$WORK/minio"
+        minio_bin="$WORK/minio"
+    fi
+    MINIO_ROOT_USER=keelhaven-bench MINIO_ROOT_PASSWORD=keelhaven-bench-secret \
+        "$minio_bin" server --address "127.0.0.1:$MINIO_PORT" "$WORK/minio-data" \
+        >"$WORK/minio.log" 2>&1 &
+    PIDS+=($!)
+    for _ in $(seq 1 40); do
+        curl -sf "http://127.0.0.1:$MINIO_PORT/minio/health/live" >/dev/null && return 0
+        sleep 0.5
+    done
+    echo "MinIO did not become healthy; log:" >&2; cat "$WORK/minio.log" >&2; exit 1
+}
+
+start_sshd() {
+    # A throwaway sshd owned by the current user. No sudo, and the system's
+    # Remote Login setting is left exactly as it was — sshd only needs root
+    # when it has to switch users, and here it never does.
+    local d="$WORK/sshd" sftp_server=""
+    # Path differs by distribution; macOS and the common Linux layouts.
+    for candidate in /usr/libexec/sftp-server \
+                     /usr/lib/openssh/sftp-server \
+                     /usr/lib/ssh/sftp-server; do
+        [ -x "$candidate" ] && { sftp_server="$candidate"; break; }
+    done
+    [ -n "$sftp_server" ] || { echo "no sftp-server binary found" >&2; exit 1; }
+    mkdir -p "$d"; chmod 700 "$d"
+    ssh-keygen -q -t ed25519 -f "$d/host_key" -N "" -C bench-host
+    ssh-keygen -q -t ed25519 -f "$d/id_bench" -N "" -C bench-client
+    cp "$d/id_bench.pub" "$d/authorized_keys"
+    chmod 600 "$d/host_key" "$d/id_bench" "$d/authorized_keys"
+    cat >"$d/sshd_config" <<EOF
+Port $SSHD_PORT
+ListenAddress 127.0.0.1
+HostKey $d/host_key
+AuthorizedKeysFile $d/authorized_keys
+PidFile $d/sshd.pid
+UsePAM no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+StrictModes no
+Subsystem sftp $sftp_server
+EOF
+    /usr/sbin/sshd -f "$d/sshd_config" -D -e >"$d/sshd.log" 2>&1 &
+    PIDS+=($!)
+    for _ in $(seq 1 40); do
+        ssh_bench "$SSHD_PORT" true 2>/dev/null && return 0
+        sleep 0.5
+    done
+    echo "sshd did not come up; log:" >&2; cat "$d/sshd.log" >&2; exit 1
+}
+
+SSH_COMMON=(-o BatchMode=yes -o StrictHostKeyChecking=no
+            -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+ssh_bench() { # port, then the remote command
+    local port="$1"; shift
+    ssh "${SSH_COMMON[@]}" -i "$WORK/sshd/id_bench" -p "$port" 127.0.0.1 "$@"
+}
+sftp_args() { echo "-p $1 -i $WORK/sshd/id_bench ${SSH_COMMON[*]}"; }
+
+# restic invocation for a backend at a given port.
+restic_at() { # backend, port, then restic args
+    local backend="$1" port="$2"; shift 2
+    if [ "$backend" = s3 ]; then
+        AWS_ACCESS_KEY_ID=keelhaven-bench AWS_SECRET_ACCESS_KEY=keelhaven-bench-secret \
+        RESTIC_PASSWORD=bench \
+            restic -r "s3:http://127.0.0.1:$port/kh-bench/repo" "$@"
+    else
+        RESTIC_PASSWORD=bench \
+            restic -o "sftp.args=$(sftp_args "$port")" \
+                   -r "sftp:$(whoami)@127.0.0.1:$WORK/sftp-repo" "$@"
+    fi
+}
+
+# ---------------------------------------------------------------- setup
+
+for backend in $BACKENDS; do
+    case "$backend" in
+        s3)   start_minio ;;
+        sftp) mkdir -p "$WORK/sftp-repo"; start_sshd ;;
+        *)    echo "unknown backend: $backend" >&2; exit 1 ;;
+    esac
+done
+
+for backend in $BACKENDS; do
+    base_port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+    say "Seeding the $backend repository"
+    restic_at "$backend" "$base_port" init >/dev/null 2>&1
+    restic_at "$backend" "$base_port" backup "$WORK/src" --no-scan >/dev/null 2>&1
+done
+
+# One proxy per (backend, rtt). RTT 0 talks to the backend directly, so the
+# proxy's own overhead never hides in the baseline.
+index=0
+for rtt in $RTTS; do
+    [ "$rtt" = 0 ] && { index=$((index + 1)); continue; }
+    for backend in $BACKENDS; do
+        upstream=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+        python3 "$SCRIPT_DIR/netdelay.py" "$(proxy_port "$backend" "$index")" "$upstream" "$rtt" \
+            >/dev/null 2>&1 &
+        PIDS+=($!)
+    done
+    index=$((index + 1))
+done
+sleep 1
+
+# ---------------------------------------------------------------- measure
+
+CACHE="$WORK/cache"
+DEEP="$WORK/src/dir000/sub0"
+
+printf '\n'
+say "restic ls — ${FILES} files, times in seconds"
+printf '%-16s %10s %10s %10s %10s\n' "backend · rtt" "full/cold" "full/warm" "one-level" "connect"
+printf '%s\n' "--------------------------------------------------------------"
+
+for backend in $BACKENDS; do
+    index=0
+    for rtt in $RTTS; do
+        if [ "$rtt" = 0 ]; then
+            port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+        else
+            port="$(proxy_port "$backend" "$index")"
+        fi
+        index=$((index + 1))
+
+        snap="$(restic_at "$backend" "$port" snapshots --json --no-lock --cache-dir "$CACHE" 2>/dev/null \
+                | python3 -c 'import json,sys; print(json.load(sys.stdin)[-1]["id"])')"
+
+        rm -rf "$CACHE"
+        t0="$(now)"; restic_at "$backend" "$port" ls --json "$snap" --recursive --no-lock --cache-dir "$CACHE" >/dev/null 2>&1; t1="$(now)"
+        cold="$(elapsed "$t0" "$t1")"
+
+        t0="$(now)"; restic_at "$backend" "$port" ls --json "$snap" --recursive --no-lock --cache-dir "$CACHE" >/dev/null 2>&1; t1="$(now)"
+        warm="$(elapsed "$t0" "$t1")"
+
+        t0="$(now)"; restic_at "$backend" "$port" ls --json "$snap" "$DEEP" --no-lock --cache-dir "$CACHE" >/dev/null 2>&1; t1="$(now)"
+        one="$(elapsed "$t0" "$t1")"
+
+        # `snapshots` is the cheapest repository operation there is, so its
+        # time is essentially the cost of connecting and opening the
+        # repository — the price every extra restic invocation pays.
+        t0="$(now)"; restic_at "$backend" "$port" snapshots --no-lock --cache-dir "$CACHE" >/dev/null 2>&1; t1="$(now)"
+        connect="$(elapsed "$t0" "$t1")"
+
+        printf '%-16s %10s %10s %10s %10s\n' "$backend · ${rtt}ms" "$cold" "$warm" "$one" "$connect"
+    done
+done
+
+if [ "$NO_CACHE" = 1 ]; then
+    printf '\n'
+    say "With restic's cache disabled (--no-cache)"
+    printf '%-16s %10s\n' "backend · rtt" "full"
+    printf '%s\n' "---------------------------"
+    for backend in $BACKENDS; do
+        index=0
+        for rtt in $RTTS; do
+            if [ "$rtt" = 0 ]; then
+                port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+            else
+                port="$(proxy_port "$backend" "$index")"
+            fi
+            index=$((index + 1))
+            snap="$(restic_at "$backend" "$port" snapshots --json --no-lock --cache-dir "$CACHE" 2>/dev/null \
+                    | python3 -c 'import json,sys; print(json.load(sys.stdin)[-1]["id"])')"
+            t0="$(now)"; restic_at "$backend" "$port" ls --json "$snap" --recursive --no-lock --no-cache >/dev/null 2>&1; t1="$(now)"
+            printf '%-16s %10s\n' "$backend · ${rtt}ms" "$(elapsed "$t0" "$t1")"
+        done
+    done
+fi
+
+printf '\n'
+say "Done. Servers stopped and temp data removed on exit."

--- a/Scripts/netdelay.py
+++ b/Scripts/netdelay.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""TCP proxy that injects propagation delay in both directions.
+
+Used by bench-remote-ls.sh to put a realistic round-trip between restic and a
+backend that is actually running on loopback. Protocol-agnostic on purpose:
+the same proxy fronts MinIO (HTTP) and sshd (SSH), so the two backends are
+measured under identical conditions.
+
+Every chunk is stamped with `arrival + RTT/2` and held by a sender thread
+until that deadline. That is deliberately not the same as sleeping once per
+request: chunks stay in flight concurrently, so a protocol's own pipelining
+still pays off instead of being flattened into a serial round-trip count —
+which is exactly the difference this benchmark is trying to measure.
+
+Nothing is parsed or rewritten. S3 request signing covers the Host header, so
+a proxy that touched the bytes would be rejected by MinIO; staying at the TCP
+layer also means SSH's encrypted stream needs no special handling.
+
+Usage: netdelay.py <listen-port> <upstream-port> <rtt-ms>
+"""
+import socket
+import sys
+import threading
+import time
+import queue
+
+LISTEN, UPSTREAM, RTT_MS = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3])
+ONE_WAY = RTT_MS / 2000.0  # seconds, half the round trip per direction
+
+
+def pump(src, dst):
+    """Forward src → dst, holding each chunk for one-way delay."""
+    q = queue.Queue()
+
+    def sender():
+        while True:
+            item = q.get()
+            if item is None:
+                break
+            deadline, data = item
+            gap = deadline - time.time()
+            if gap > 0:
+                time.sleep(gap)
+            try:
+                dst.sendall(data)
+            except OSError:
+                break
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+    thread = threading.Thread(target=sender, daemon=True)
+    thread.start()
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            q.put((time.time() + ONE_WAY, data))
+    except OSError:
+        pass
+    q.put(None)
+    thread.join()
+
+
+def handle(client):
+    try:
+        upstream = socket.create_connection(("127.0.0.1", UPSTREAM))
+    except OSError:
+        client.close()
+        return
+    up = threading.Thread(target=pump, args=(client, upstream), daemon=True)
+    down = threading.Thread(target=pump, args=(upstream, client), daemon=True)
+    up.start()
+    down.start()
+    up.join()
+    down.join()
+    client.close()
+    upstream.close()
+
+
+def main():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", LISTEN))
+    server.listen(128)
+    print(f"netdelay :{LISTEN} -> :{UPSTREAM}  rtt={RTT_MS}ms", flush=True)
+    while True:
+        conn, _ = server.accept()
+        threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Snapshot browsing is about to be built on `restic ls`, and *how* it gets built depends on numbers a laptop can't produce. On loopback, S3 and SFTP are indistinguishable from a local disk (~0.6 s either way) — nothing about a bucket in another region, or a NAS across a VPN, shows up at all.

## What's here

`make bench-remote` stands up its own MinIO and a throwaway sshd, fronts them with `Scripts/netdelay.py` to inject a round trip in both directions, and times `restic ls`.

```bash
make bench-remote                                      # 15k files, 0/20/60 ms
BENCH_FILES=2000 BENCH_RTTS="0 100" make bench-remote   # quick, or a slow link
```

Unprivileged and self-cleaning: the sshd is a private instance on a high port with its own host key, so **your Remote Login setting is never touched**, and every server and temp file goes away on exit. MinIO is downloaded if it isn't installed.

The proxy holds each chunk for half the round trip instead of sleeping once per request. That matters: sleeping per request flattens a protocol's own pipelining into a serial round-trip count, which is exactly the difference the SFTP column exists to show. It also stays at the TCP layer — S3 request signing covers the Host header, so a proxy that rewrote anything would be rejected, and SSH's encrypted stream needs no special handling either.

## What it found

15,732 files, times in seconds:

| backend · rtt | full/cold | full/warm | one-level | connect |
|---|---|---|---|---|
| s3 · 0ms | 0.80 | 0.79 | 0.58 | 0.65 |
| s3 · 60ms | 1.57 | 1.32 | 1.13 | 1.02 |
| sftp · 0ms | 0.81 | 0.80 | 0.58 | 0.56 |
| sftp · 60ms | 4.38 | 3.33 | 3.09 | **2.72** |

Identical on loopback, 2.7× apart at 60 ms. The `connect` column is why: opening the repository costs 1.0 s on S3 and 2.7 s on SFTP, where SSH key exchange, auth and starting the sftp subsystem come to roughly 36 round trips. **That cost is paid per restic invocation**, which rules out per-directory lazy loading on SFTP well before any other number matters.

One more, with `BENCH_NO_CACHE=1`: the same listing goes from 1.3 s to 62.7 s on S3 at 60 ms (7 requests → 903). restic's cache isn't an optimisation here, it's the thing that makes remote browsing viable at all.

## Why not in `ci.yml`

Manual trigger, own workflow. A full matrix is minutes of 10×-billed macOS runner — `ci.yml`'s header notes the quota ran dry once — and shared-runner CPU noise would make a gating number flaky. The **ratios** hold up across runs; the absolute times wobble, so they shouldn't gate anything.

The workflow writes its table into the run summary. `Scripts/` is cross-platform (sftp-server path and MinIO arch are detected), so switching the runner to `ubuntu-latest` for 1× billing is a one-line change if the macOS-specific behaviour ever stops mattering.

Verified locally: shellcheck clean, and the script reproduces the hand-measured numbers it was built from (SFTP connect 2.73 s vs 2.72 s hand-measured).