### PR TITLE
Stop telling users to install an engine that ships in the app

### DIFF
--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -2090,16 +2090,6 @@
         }
       }
     },
-    "restic was not found. Install it with: brew install restic": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到 restic 备份引擎。请用以下命令安装：brew install restic"
-          }
-        }
-      }
-    },
     "s3.amazonaws.com": {
       "shouldTranslate": false
     },

--- a/Keelhaven/MenuBar/MenuBarView.swift
+++ b/Keelhaven/MenuBar/MenuBarView.swift
@@ -38,8 +38,13 @@ struct MenuBarView: View {
             }
 
             if appState.resticBinaryURL == nil {
+                // Deliberately the same sentence the failure path throws, read
+                // straight off the error rather than restated here: the two
+                // drifted apart once already, and this copy is the one users
+                // meet first — it sits at the top of the panel on launch,
+                // while the other only appears once something is attempted.
                 Label(
-                    "restic was not found. Install it with: brew install restic",
+                    ResticError.binaryNotFound.localizedDescription,
                     systemImage: "exclamationmark.triangle"
                 )
                 .font(.callout)


### PR DESCRIPTION
[#27](https://github.com/shenxianpeng/keelhaven/pull/27) fixed this sentence on `ResticError.binaryNotFound` but missed a second, hand-written copy in `MenuBarView` — and that copy is the one users actually meet. It sits at the top of the menu bar panel from launch whenever the engine can't be found; the error's version only shows up once something is attempted.

Both said:

> restic was not found. Install it with: `brew install restic`
> 找不到 restic 备份引擎。请用以下命令安装：brew install restic

The engine ships inside the app bundle, and the site FAQ promises there is nothing else to install. The one moment this sentence appears — a damaged or quarantined bundle — is the one moment it must not send people somewhere wrong. Worth fixing before launch: a first-time user hitting a bad bundle would read this as their first impression of the app.

## The fix

Rather than restate the corrected sentence, the panel now reads it off `ResticError.binaryNotFound`. One source, so the two can't drift apart a second time, and one less string to keep translated (the App catalog drops from 214 to 213).

## Deliberately left alone

The `Keelhaven needs restic 0.19 or newer. Update it with: brew upgrade restic` startup warning. The bundled binary is pinned at 0.19.1 and always satisfies the minimum, so that one can only fire when the user has overridden the binary path or a dev build fell back to Homebrew — cases where an external restic genuinely is in use and pointing at brew is the right advice.

Swept the rest of both catalogs: no other user-visible string tells anyone to install or upgrade restic.

112 tests green, app builds.