### PR TITLE
Never let a confirmed plan deletion do nothing

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -15,6 +15,15 @@ enum PlanRunState: Equatable {
     /// from `failed` for one reason: it is the only failure the row can offer
     /// a fix for, so it carries an unlock button instead of dead red text.
     case failedLocked(String)
+
+    /// A restic process is going for this plan right now. The four cases that
+    /// hold the repository lock; everything else is a resting state.
+    var isActive: Bool {
+        switch self {
+        case .running, .checking, .pruning, .unlocking: return true
+        default: return false
+        }
+    }
 }
 
 /// Root observable state: owns the plan list, run states, and all services.
@@ -120,12 +129,7 @@ final class AppState {
 
     var menuBarIcon: MenuBarIcon {
         let states = runStates.values
-        if states.contains(where: {
-            switch $0 {
-            case .running, .checking, .pruning, .unlocking: return true
-            default: return false
-            }
-        }) {
+        if states.contains(where: \.isActive) {
             return .symbol("arrow.triangle.2.circlepath")
         }
         if states.contains(where: {
@@ -191,8 +195,27 @@ final class AppState {
         }
     }
 
-    func deletePlan(_ plan: BackupPlan) {
-        guard !isResticBusy else { return }
+    /// Why `deletePlan` declined, so the caller can say so. It used to
+    /// `guard !isResticBusy else { return }` — and a delete the user had just
+    /// confirmed and authenticated with Touch ID would then do nothing at all,
+    /// which on screen is indistinguishable from the list failing to refresh.
+    /// The window was easy to hit: a scheduled `restic check` chains straight
+    /// off a finished backup, so "Back Up Now, then delete" landed inside it.
+    enum DeleteRefusal: Equatable {
+        /// This plan's own backup, check, prune or unlock is mid-flight.
+        case planIsActive
+    }
+
+    /// Removes a plan, its run states, its Keychain secrets and its history.
+    /// Declines only while *this* plan's restic is running: that process holds
+    /// the repository and its credentials, and pulling them out from under it
+    /// is the one thing here that could leave the destination inconsistent.
+    /// Another plan's run is unrelated (its secrets and process are its own),
+    /// and the scheduler never starts a second restic while one is going, so
+    /// deleting under it is safe.
+    @discardableResult
+    func deletePlan(_ plan: BackupPlan) -> DeleteRefusal? {
+        if (runStates[plan.id] ?? .idle).isActive { return .planIsActive }
         plans.removeAll { $0.id == plan.id }
         runStates.removeValue(forKey: plan.id)
         planManager.removeSecrets(planID: plan.id)
@@ -200,6 +223,7 @@ final class AppState {
             try? await planStore.save(plans)
             try? await historyStore.deleteHistory(for: plan.id)
         }
+        return nil
     }
 
     // MARK: - Running backups
@@ -208,12 +232,7 @@ final class AppState {
     /// repository check, a retention pass, or an unlock. One restic at a time,
     /// app-wide: two invocations would contend for the repository lock.
     var isResticBusy: Bool {
-        runStates.values.contains {
-            switch $0 {
-            case .running, .checking, .pruning, .unlocking: return true
-            default: return false
-            }
-        }
+        runStates.values.contains(where: \.isActive)
     }
 
     private func runDuePlans() {

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -104,6 +104,16 @@
         }
       }
     },
+    "A backup or repository check for this plan is still running. Wait for it to finish, then delete the plan.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个计划的备份或仓库校验还在进行中。等它结束后再删除。"
+          }
+        }
+      }
+    },
     "A month of history": {
       "localizations": {
         "zh-Hans": {
@@ -2092,6 +2102,16 @@
     },
     "s3.amazonaws.com": {
       "shouldTranslate": false
+    },
+    "“%@” is busy right now": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@”正在忙"
+          }
+        }
+      }
     },
     "⌘Q": {
       "shouldTranslate": false

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -156,7 +156,8 @@ struct PlanStatusRow: View {
         Button("Delete Backup Plan…", role: .destructive) {
             confirmAndDelete()
         }
-        .disabled(appState.isResticBusy)
+        // Only this plan's own run blocks deletion — see AppState.deletePlan.
+        .disabled(runState.isActive)
     }
 
     /// Confirmation dialogs use app-modal NSAlert, not SwiftUI `.alert`:
@@ -229,8 +230,24 @@ struct PlanStatusRow: View {
             guard await BiometricAuthService.authenticate(
                 reason: String(localized: "delete the backup plan “\(plan.name)”")
             ) else { return }
-            appState.deletePlan(plan)
+            // Seconds pass in Touch ID; the plan can start a scheduled check
+            // meanwhile. The menu item was enabled when clicked, so if the
+            // delete is declined now, say so — a silent no-op after a confirm
+            // and a fingerprint reads as "it didn't work".
+            if appState.deletePlan(plan) == .planIsActive {
+                explainDeleteDeclined()
+            }
         }
+    }
+
+    private func explainDeleteDeclined() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = String(localized: "“\(plan.name)” is busy right now")
+        alert.informativeText = String(localized: "A backup or repository check for this plan is still running. Wait for it to finish, then delete the plan.")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## What was wrong

Deleting a plan from the menu bar panel could look like the list failing to refresh: the row stayed, the plan was still listed on reopen, and only a relaunch sorted it out.

The list was fine. `AppState.deletePlan` began with `guard !isResticBusy else { return }`, so whenever *any* restic process was running app-wide, a delete the user had just confirmed and authenticated with Touch ID did nothing at all, with nothing on screen to say so.

The window was easy to hit. A scheduled `restic check` chains straight off a finished backup (`performBackup`), so "Back Up Now, watch it finish, delete" landed the delete inside the check. The menu item was enabled when clicked; the guard ran seconds later, after Touch ID.

## What changes

- **`deletePlan` declines only while this plan's own restic is mid-flight.** That is the one case where pulling its credentials could leave the destination inconsistent. Another plan's run is unrelated (its own process, its own secrets), and the scheduler never overlaps two restic processes, so deleting under it is safe.
- **It returns a reason (`DeleteRefusal?`) instead of nothing.** `PlanStatusRow` shows an alert ("“<plan>” is busy right now") when the delete is declined, rather than swallowing a destructive action the user just approved. The Delete menu item's enabled state follows the same per-plan rule.
- **`PlanRunState.isActive`** replaces three copies of the same four-case switch (`isResticBusy`, `menuBarIcon`, and the new guard).
- Two new strings with zh-Hans translations in `Localizable.xcstrings`.

## How to check

```bash
swift test --package-path KeelhavenCore
xcodegen generate && xcodebuild -project Keelhaven.xcodeproj -scheme Keelhaven build
```

On screen, with a throwaway plan whose source and destination are both under `/tmp`:

1. Back Up Now, wait for green. The scheduled check usually starts right after.
2. While the check runs, Delete in the ⋯ menu should be disabled. If you click Delete before the check starts and it begins during Touch ID, you should get the "busy" alert instead of silence.
3. Delete after the check finishes: the row disappears immediately, without closing the panel.

No KeelhavenCore changes, so the coverage gate is unaffected.