### PR TITLE
Let a plan be created without starting its first backup

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -154,8 +154,12 @@ final class AppState {
         plans.append(plan)
         runStates[plan.id] = .idle
         try await planStore.save(plans)
-        // The wizard promises the first backup starts right after creation —
-        // kick the scheduler now instead of waiting up to 60s for its tick.
+        // Kick the scheduler now instead of waiting up to 60s for its tick.
+        // Whether that actually starts a backup is `SchedulePolicy.isDue`'s
+        // call: a plan created with "Start the first backup now" unchecked is
+        // not due yet, so this is a no-op for it (issue #42). Deliberately not
+        // an `if` here — the flag has to hold across relaunches too, and only
+        // the policy is asked on every tick and at launch.
         runDuePlans()
     }
 

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -1907,6 +1907,16 @@
         }
       }
     },
+    "Start the first backup now": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即开始首次备份"
+          }
+        }
+      }
+    },
     "Step %lld of %lld: %@": {
       "localizations": {
         "zh-Hans": {
@@ -1983,6 +1993,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "上一次保留策略清理没能获得仓库的锁"
+          }
+        }
+      }
+    },
+    "The plan is created but stays idle: the first backup runs at %@, then on this schedule — catching up automatically if your Mac was asleep or off. You can always start one yourself with Back Up Now.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "计划会创建好但先不动：首次备份将在 %@ 运行，之后按此计划进行——睡眠或关机错过的时间点会自动补跑。你也随时可以用「立即备份」手动跑一次。"
           }
         }
       }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -32,11 +32,11 @@ struct PlanStatusRow: View {
 
     /// When the next scheduled run is due, shown as a tooltip on the status line.
     private var nextRunText: String {
-        let next = SchedulePolicy.nextRun(
-            for: plan.schedule,
-            after: plan.lastRun?.date ?? Date(),
-            calendar: .current
-        )
+        // Asks the policy about the whole plan, not just its schedule: a
+        // never-run plan's anchor depends on how it was created, and computing
+        // it here from `Date()` made this line disagree with the scheduler
+        // (issue #42).
+        let next = SchedulePolicy.nextRun(for: plan)
         if next <= Date() {
             return String(localized: "Next backup: as soon as possible")
         }

--- a/Keelhaven/Services/PlanManager.swift
+++ b/Keelhaven/Services/PlanManager.swift
@@ -16,6 +16,8 @@ struct PlanDraft {
     var checkCadence: CheckCadence = .weekly
     var retention: RetentionPolicy = .off
     var performance: PerformanceOptions = .off
+    /// The wizard's "Start the first backup now" checkbox (issue #42).
+    var firstBackupStartsOnCreation: Bool = true
     var password: String
     var s3SecretKey: String?
     var restPassword: String?
@@ -54,7 +56,8 @@ struct PlanManager {
             excludePatterns: draft.excludePatterns,
             checkCadence: draft.checkCadence,
             retention: draft.retention,
-            performance: draft.performance
+            performance: draft.performance,
+            firstBackupStartsOnCreation: draft.firstBackupStartsOnCreation
         )
 
         let credentials = RepoCredentials(

--- a/Keelhaven/Wizard/ScheduleStepView.swift
+++ b/Keelhaven/Wizard/ScheduleStepView.swift
@@ -15,19 +15,7 @@ struct ScheduleStepView: View {
 
                 ScheduleEditor(kind: $model.scheduleKind, dailyTime: $model.dailyTime, weekday: $model.weekday)
 
-                // Surprise-proofing, not decoration: the first run starts on
-                // creation (SchedulePolicy treats a never-run plan as due), and
-                // users who set an evening time expect silence until then. One
-                // footnote-sized block, System Settings style — not two callout
-                // paragraphs competing with the summary.
-                //
-                // It is also why Customize sits on this step rather than in
-                // Edit Plan alone: a backup that starts this soon has to be
-                // configurable before it does (issue #41).
-                Text("The first backup starts as soon as you create the plan. After that, backups run on this schedule, catching up automatically if your Mac was asleep or off.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                firstBackupRow
 
                 customizeSection
 
@@ -37,6 +25,41 @@ struct ScheduleStepView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    /// The checkbox and the sentence that explains it, as one block.
+    ///
+    /// They belong together: the sentence *is* the promise the checkbox
+    /// changes, and splitting the control into the summary below would leave
+    /// a bare checkbox in a read-only recap and a claim up here that the
+    /// choice can contradict (issue #42). On by default, so nobody who does
+    /// not care ever has to look at it — unticking is the whole opt-in.
+    private var firstBackupRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("Start the first backup now", isOn: $model.firstBackupStartsOnCreation)
+                .toggleStyle(.checkbox)
+            // Surprise-proofing, not decoration: users who set an evening time
+            // expect silence until then. One footnote-sized block, System
+            // Settings style — not two callout paragraphs competing with the
+            // summary.
+            Text(firstBackupExplanation)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Says what will actually happen, naming the concrete time when the first
+    /// backup is going to wait for it — "at the next scheduled time" alone
+    /// leaves the user doing the arithmetic.
+    private var firstBackupExplanation: String {
+        let schedule = Schedule(kind: model.scheduleKind, dailyTime: model.dailyTime, weekday: model.weekday)
+        if model.firstBackupStartsOnCreation {
+            return String(localized: "The first backup starts as soon as you create the plan. After that, backups run on this schedule, catching up automatically if your Mac was asleep or off.")
+        }
+        let first = SchedulePolicy.nextRun(for: schedule, after: Date(), calendar: .current)
+            .formatted(date: .abbreviated, time: .shortened)
+        return String(localized: "The plan is created but stays idle: the first backup runs at \(first), then on this schedule — catching up automatically if your Mac was asleep or off. You can always start one yourself with Back Up Now.")
     }
 
     /// The four settings Edit Plan offers, collapsed — and staying collapsed

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -129,6 +129,10 @@ final class WizardModel {
         }
     }
 
+    /// "Start the first backup now", on by default — the behaviour every
+    /// plan had before the checkbox existed (issue #42).
+    var firstBackupStartsOnCreation = true
+
     var scheduleKind: ScheduleKind = .daily
     var dailyTime = Calendar.current.date(bySettingHour: 21, minute: 0, second: 0, of: Date()) ?? Date()
     /// Calendar weekday (1 = Sunday); defaults to the region's first weekday.
@@ -358,6 +362,7 @@ final class WizardModel {
             checkCadence: options.checkCadence,
             retention: options.retention,
             performance: options.builtPerformance(),
+            firstBackupStartsOnCreation: firstBackupStartsOnCreation,
             password: password,
             s3SecretKey: destinationType == .s3 ? s3SecretKey : nil,
             restPassword: destinationType == .rest ? restPassword : nil,
@@ -391,6 +396,7 @@ final class WizardModel {
         adoptExistingRepository = fresh.adoptExistingRepository
         isVerifyingPassword = fresh.isVerifyingPassword
         passwordVerificationError = fresh.passwordVerificationError
+        firstBackupStartsOnCreation = fresh.firstBackupStartsOnCreation
         scheduleKind = fresh.scheduleKind
         dailyTime = fresh.dailyTime
         weekday = fresh.weekday

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
@@ -15,6 +15,15 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
     public var retention: RetentionPolicy
     /// restic throughput knobs, all off by default. See `PerformanceOptions`.
     public var performance: PerformanceOptions
+    /// Whether the very first backup starts the moment the plan is created,
+    /// rather than waiting for the first scheduled time after `createdAt`.
+    ///
+    /// Persisted rather than kept in the wizard, because the alternative does
+    /// not survive a relaunch: `SchedulePolicy` is asked once a minute and at
+    /// every launch, so a plan that only *skipped* its creation-time run would
+    /// be started by the very next tick (issue #42). Only consulted while
+    /// `lastRun` is nil; after the first run the schedule anchors there.
+    public var firstBackupStartsOnCreation: Bool
     public var createdAt: Date
     public var lastRun: BackupRunRecord?
     public var lastCheck: CheckRunRecord?
@@ -37,6 +46,7 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         checkCadence: CheckCadence = .weekly,
         retention: RetentionPolicy = .off,
         performance: PerformanceOptions = .off,
+        firstBackupStartsOnCreation: Bool = true,
         createdAt: Date = Date(),
         lastRun: BackupRunRecord? = nil,
         lastCheck: CheckRunRecord? = nil,
@@ -51,6 +61,7 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         self.checkCadence = checkCadence
         self.retention = retention
         self.performance = performance
+        self.firstBackupStartsOnCreation = firstBackupStartsOnCreation
         self.createdAt = createdAt
         self.lastRun = lastRun
         self.lastCheck = lastCheck
@@ -72,6 +83,10 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         checkCadence = try container.decodeIfPresent(CheckCadence.self, forKey: .checkCadence) ?? .weekly
         retention = try container.decodeIfPresent(RetentionPolicy.self, forKey: .retention) ?? .off
         performance = try container.decodeIfPresent(PerformanceOptions.self, forKey: .performance) ?? .off
+        // Absent on every plan written before this flag existed — and those
+        // all started their first backup on creation, so `true` is the value
+        // that keeps them behaving exactly as they did.
+        firstBackupStartsOnCreation = try container.decodeIfPresent(Bool.self, forKey: .firstBackupStartsOnCreation) ?? true
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         lastRun = try container.decodeIfPresent(BackupRunRecord.self, forKey: .lastRun)
         lastCheck = try container.decodeIfPresent(CheckRunRecord.self, forKey: .lastCheck)

--- a/KeelhavenCore/Sources/KeelhavenCore/Scheduling/SchedulePolicy.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Scheduling/SchedulePolicy.swift
@@ -35,17 +35,39 @@ public enum SchedulePolicy {
         }
     }
 
-    /// A plan is due when it has never run, or when its next scheduled time
-    /// after the last run is in the past. Missed runs (Mac was asleep or the
-    /// app wasn't running) therefore make the plan due immediately.
+    /// When this plan's next backup is expected, from one anchor rule:
+    ///
+    /// - it has run before → the first scheduled time after that run;
+    /// - never run, created to start right away → `createdAt`, i.e. already
+    ///   past, so it is due the moment the plan exists;
+    /// - never run, created to wait → the first scheduled time after
+    ///   `createdAt` (issue #42).
+    ///
+    /// `isDue` is defined in terms of this rather than repeating the anchor,
+    /// so the menu bar's "Next backup:" line and the scheduler can never
+    /// disagree about when a plan runs — they used to, for a fresh plan.
+    public static func nextRun(
+        for plan: BackupPlan,
+        calendar: Calendar = .current
+    ) -> Date {
+        guard let lastRunDate = plan.lastRun?.date else {
+            return plan.firstBackupStartsOnCreation
+                ? plan.createdAt
+                : nextRun(for: plan.schedule, after: plan.createdAt, calendar: calendar)
+        }
+        return nextRun(for: plan.schedule, after: lastRunDate, calendar: calendar)
+    }
+
+    /// A plan is due once its expected next run is in the past. Missed runs
+    /// (Mac was asleep or the app wasn't running) therefore make the plan due
+    /// immediately, and stay that way until it actually runs — so a plan whose
+    /// creation-time backup was skipped because restic was busy is picked up
+    /// by the next tick.
     public static func isDue(
         _ plan: BackupPlan,
         now: Date,
         calendar: Calendar = .current
     ) -> Bool {
-        guard let lastRunDate = plan.lastRun?.date else {
-            return true
-        }
-        return nextRun(for: plan.schedule, after: lastRunDate, calendar: calendar) <= now
+        nextRun(for: plan, calendar: calendar) <= now
     }
 }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -147,6 +147,7 @@ final class ModelRoundTripTests: XCTestCase {
         object.removeValue(forKey: "retention")
         object.removeValue(forKey: "lastPrune")
         object.removeValue(forKey: "performance")
+        object.removeValue(forKey: "firstBackupStartsOnCreation")
         let legacyData = try JSONSerialization.data(withJSONObject: object)
 
         let decoder = JSONDecoder()
@@ -157,6 +158,9 @@ final class ModelRoundTripTests: XCTestCase {
         XCTAssertEqual(decoded.retention, .off)
         XCTAssertNil(decoded.lastPrune)
         XCTAssertEqual(decoded.performance, .off)
+        // Every plan written before the flag existed did start its first
+        // backup on creation, so absence must decode as true (issue #42).
+        XCTAssertTrue(decoded.firstBackupStartsOnCreation)
         XCTAssertEqual(decoded.name, plan.name)
         XCTAssertEqual(decoded.schedule, plan.schedule)
     }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/SchedulePolicyTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/SchedulePolicyTests.swift
@@ -13,12 +13,22 @@ final class SchedulePolicyTests: XCTestCase {
         return calendar.date(from: components)!
     }
 
-    private func makePlan(schedule: Schedule, lastRun: Date?) -> BackupPlan {
+    /// `createdAt` defaults to a fixed instant before every `now` the tests
+    /// use, so a never-run plan's anchor is deterministic rather than the
+    /// real clock.
+    private func makePlan(
+        schedule: Schedule,
+        lastRun: Date?,
+        firstBackupStartsOnCreation: Bool = true,
+        createdAt: Date? = nil
+    ) -> BackupPlan {
         BackupPlan(
             name: "Test",
             sourcePaths: ["/tmp/src"],
             destination: .local(path: "/tmp/repo"),
             schedule: schedule,
+            firstBackupStartsOnCreation: firstBackupStartsOnCreation,
+            createdAt: createdAt ?? utcDate(2026, 8, 1, 0, 0),
             lastRun: lastRun.map { BackupRunRecord(date: $0, success: true) }
         )
     }
@@ -44,6 +54,82 @@ final class SchedulePolicyTests: XCTestCase {
     func testNeverRanPlanIsDue() {
         let plan = makePlan(schedule: .hourly, lastRun: nil)
         XCTAssertTrue(SchedulePolicy.isDue(plan, now: utcDate(2026, 8, 14, 0, 0), calendar: calendar))
+    }
+
+    // MARK: - First run (issue #42)
+
+    /// The whole point of the flag: skipping the creation-time run is not
+    /// enough, because the scheduler asks again every minute. A plan created
+    /// to wait must actually report "not due".
+    func testPlanCreatedToWaitIsNotDueBeforeItsFirstScheduledTime() {
+        let plan = makePlan(
+            schedule: .daily(hour: 21, minute: 0),
+            lastRun: nil,
+            firstBackupStartsOnCreation: false,
+            createdAt: utcDate(2026, 8, 14, 10, 0)
+        )
+        XCTAssertFalse(SchedulePolicy.isDue(plan, now: utcDate(2026, 8, 14, 10, 1), calendar: calendar))
+        XCTAssertFalse(SchedulePolicy.isDue(plan, now: utcDate(2026, 8, 14, 20, 59), calendar: calendar))
+    }
+
+    func testPlanCreatedToWaitBecomesDueAtItsFirstScheduledTime() {
+        let plan = makePlan(
+            schedule: .daily(hour: 21, minute: 0),
+            lastRun: nil,
+            firstBackupStartsOnCreation: false,
+            createdAt: utcDate(2026, 8, 14, 10, 0)
+        )
+        XCTAssertTrue(SchedulePolicy.isDue(plan, now: utcDate(2026, 8, 14, 21, 0), calendar: calendar))
+    }
+
+    /// A plan created to wait, whose first scheduled time passed while the Mac
+    /// was off, still catches up — it does not silently skip a window.
+    func testPlanCreatedToWaitCatchesUpAfterAMissedFirstWindow() {
+        let plan = makePlan(
+            schedule: .daily(hour: 21, minute: 0),
+            lastRun: nil,
+            firstBackupStartsOnCreation: false,
+            createdAt: utcDate(2026, 8, 14, 10, 0)
+        )
+        XCTAssertTrue(SchedulePolicy.isDue(plan, now: utcDate(2026, 8, 20, 9, 0), calendar: calendar))
+    }
+
+    func testNextRunOfPlanCreatedToStartNowIsItsCreationTime() {
+        let created = utcDate(2026, 8, 14, 10, 0)
+        let plan = makePlan(schedule: .daily(hour: 21, minute: 0), lastRun: nil, createdAt: created)
+        XCTAssertEqual(SchedulePolicy.nextRun(for: plan, calendar: calendar), created)
+    }
+
+    func testNextRunOfPlanCreatedToWaitIsTheFirstScheduledTimeAfterCreation() {
+        let plan = makePlan(
+            schedule: .daily(hour: 21, minute: 0),
+            lastRun: nil,
+            firstBackupStartsOnCreation: false,
+            createdAt: utcDate(2026, 8, 14, 10, 0)
+        )
+        XCTAssertEqual(
+            SchedulePolicy.nextRun(for: plan, calendar: calendar),
+            utcDate(2026, 8, 14, 21, 0)
+        )
+    }
+
+    /// Once it has run, the flag stops mattering — the anchor is the last run.
+    func testNextRunOfPlanThatHasRunAnchorsOnTheLastRun() {
+        let plan = makePlan(
+            schedule: .daily(hour: 21, minute: 0),
+            lastRun: utcDate(2026, 8, 14, 21, 0),
+            firstBackupStartsOnCreation: false,
+            createdAt: utcDate(2026, 8, 1, 0, 0)
+        )
+        XCTAssertEqual(
+            SchedulePolicy.nextRun(for: plan, calendar: calendar),
+            utcDate(2026, 8, 15, 21, 0)
+        )
+    }
+
+    func testNextRunForPlanUsesCurrentCalendarByDefault() {
+        let plan = makePlan(schedule: .hourly, lastRun: nil, createdAt: utcDate(2026, 8, 14, 10, 0))
+        XCTAssertEqual(SchedulePolicy.nextRun(for: plan), utcDate(2026, 8, 14, 10, 0))
     }
 
     func testHourlyPlanNotDueBeforeInterval() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,11 @@ frameworks (UserNotifications, ServiceManagement, AppKit panels).
 1. `SchedulerService` fires every 60s → `AppState.runDuePlans()`.
 2. `SchedulePolicy.isDue(plan)` — pure date math; a missed window (Mac asleep)
    makes the plan due immediately. Also checked at launch and on
-   `NSWorkspace.didWakeNotification`.
+   `NSWorkspace.didWakeNotification`. A plan that has never run anchors on
+   `createdAt`: due at once if it was created with "Start the first backup
+   now", otherwise at the first scheduled time after creation. That flag is
+   persisted on the plan rather than acted on once at creation, because this
+   function is the only thing consulted on every tick and at every launch.
 3. `AppState` reads secrets from the Keychain (`KeychainAccount` names are
    keyed by plan UUID), builds `RepoCredentials`.
 4. `ResticRunner.backupStream(...)` spawns `restic backup --json` with a


### PR DESCRIPTION
Fixes #42

## The problem

The wizard promised *"The first backup starts as soon as you create the plan"* and offered no way to decline. Anyone who wanted different excludes or retention watched a full backup run on the defaults first — the second half of the complaint in #39.

## Why the issue's proposed fix does not work

The issue suggests having `AppState.createPlan` call `runDuePlans()` only when the box is ticked, noting that *"`SchedulePolicy.isDue` already handles a plan that has never run."* It does — by making it due immediately:

```swift
guard let lastRunDate = plan.lastRun?.date else {
    return true          // never run → always due
}
```

`isDue` is asked again by `SchedulerService` every 60 seconds and by `bootstrap()` at every launch. Skipping the call at creation would have delayed the first backup by at most a minute, and not at all across a relaunch.

**Verified empirically** against merged `main` (8cdd714), with a plan seeded as never-run and marked to wait, on an isolated `HOME`:

| build | seeded flag | after 20s |
|---|---|---|
| merged `main` | wait | `lastRun` **written** — backed up anyway |
| this branch | wait | `lastRun` absent |
| this branch | start now | `lastRun` written |

## What this does instead

The choice is persisted on the plan and read by the policy, which is the only thing consulted on every tick and at every launch.

- `BackupPlan.firstBackupStartsOnCreation`, decoding as `true` when absent — which is exactly what every plan written before it did.
- `SchedulePolicy.nextRun(for plan:)` — a whole-plan overload holding one anchor rule: last run if there is one, else `createdAt` (already past → due now), else the first scheduled time after `createdAt`. `isDue` is now defined in terms of it.
- `PlanStatusRow` uses that overload. It used to compute its own anchor from `Date()` and disagree with the scheduler for a fresh plan — the tooltip would name a future time for a plan that was actually about to run.
- `PlanDraft` and `WizardModel` carry the flag; `AppState.createPlan` still calls `runDuePlans()` unconditionally, which is now correct by construction.

A plan created to wait still catches up if its first scheduled time passed while the Mac was off, and **Back Up Now** still runs it on demand — both verified.

## Design

Per the three product principles: the box is **ticked by default**, so nothing changes for anyone who does not care, and unticking is the entire opt-in. It sits directly under the sentence it changes rather than in the Summary block the issue suggested — the sentence *is* the promise being modified, and splitting them would leave a bare checkbox in a read-only recap plus a claim above it that the choice contradicts. Happy to move it if you would rather follow the issue exactly.

When unticked, the copy names the concrete time instead of saying "at the next scheduled time" and leaving the user to do the arithmetic.

## Verification

- `swift test --package-path KeelhavenCore` — 135 passed; 7 new tests covering the wait/start-now/catch-up branches and the absent-key decode. Line coverage stays 100% on `KeelhavenCore` (`BackupPlan.swift` and `SchedulePolicy.swift` both 100%).
- Clean app build.
- Runtime: the before/after table above, plus the plan staying idle across a 60s tick **and** a relaunch, and **Back Up Now** still triggering it.
- Wizard step 3 screenshotted in both states, English and Simplified Chinese; new strings ship in both.