### PR TITLE
Add `--exclude-caches` and `--skip-if-unchanged` as named backup options

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -184,7 +184,8 @@ final class AppState {
         schedule: Schedule,
         checkCadence: CheckCadence,
         retention: RetentionPolicy,
-        performance: PerformanceOptions
+        performance: PerformanceOptions,
+        backupOptions: BackupOptions
     ) {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, !sourcePaths.isEmpty,
@@ -196,6 +197,7 @@ final class AppState {
         plans[index].checkCadence = checkCadence
         plans[index].retention = retention
         plans[index].performance = performance
+        plans[index].backupOptions = backupOptions
         Task {
             try? await planStore.save(plans)
         }
@@ -272,7 +274,8 @@ final class AppState {
                     sources: plan.sourcePaths,
                     excludes: plan.excludePatterns,
                     tag: "keelhaven",
-                    performance: plan.performance
+                    performance: plan.performance,
+                    options: plan.backupOptions
                 ),
                 destination: plan.destination,
                 credentials: credentials
@@ -288,6 +291,14 @@ final class AppState {
                 }
             }
 
+            // restic omits `snapshot_id` from its summary when
+            // `--skip-if-unchanged` finds nothing to store. Only trust that
+            // when we asked for it: the same field is also absent from the
+            // nested summary inside `restic snapshots --json`, so a bare nil
+            // check is ambiguous everywhere else (issue #46).
+            let skippedUnchanged = plan.backupOptions.skipIfUnchanged
+                && summary != nil
+                && summary?.snapshotID == nil
             let record = BackupRunRecord(
                 date: startedAt,
                 success: true,
@@ -295,11 +306,16 @@ final class AppState {
                 filesNew: summary?.filesNew,
                 filesChanged: summary?.filesChanged,
                 dataAddedBytes: summary?.dataAdded,
-                duration: summary?.totalDuration
+                duration: summary?.totalDuration,
+                skippedUnchanged: skippedUnchanged
             )
             await finishRun(plan, record: record)
             runStates[plan.id] = .succeeded(Date())
-            await NotificationService.postBackupFinished(planName: plan.name, summary: summary)
+            if skippedUnchanged {
+                await NotificationService.postBackupUnchanged(planName: plan.name)
+            } else {
+                await NotificationService.postBackupFinished(planName: plan.name, summary: summary)
+            }
             // Verification rides on the tail of a successful backup: the
             // destination is provably reachable and restic is already
             // serialized, so a due check can never fire a false alarm about

--- a/Keelhaven/EditPlan/EditPlanWindowView.swift
+++ b/Keelhaven/EditPlan/EditPlanWindowView.swift
@@ -94,7 +94,8 @@ struct EditPlanWindowView: View {
                         schedule: model.builtSchedule(),
                         checkCadence: model.options.checkCadence,
                         retention: model.options.retention,
-                        performance: model.options.builtPerformance()
+                        performance: model.options.builtPerformance(),
+                        backupOptions: model.options.builtBackupOptions()
                     )
                     dismiss()
                 }

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -51,6 +51,16 @@
         }
       }
     },
+    "%@: no changes since the last backup, so no new snapshot was created.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@：与上次备份相比没有变化，因此没有创建新的备份点。"
+          }
+        }
+      }
+    },
     "%lld backups need attention": {
       "extractionState": "manual",
       "localizations": {
@@ -650,6 +660,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "创建备份计划"
+          }
+        }
+      }
+    },
+    "Creates no new backup when the folders are identical to the last one, instead of a fresh copy that stores nothing. Keeps the list you restore from shorter.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当这些文件夹与上次备份完全相同时，不再新建一份什么都没存的备份。可以让恢复时的列表更简洁。"
           }
         }
       }
@@ -1307,6 +1327,16 @@
         }
       }
     },
+    "No changes — nothing new to back up": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有变化 —— 没有需要备份的新内容"
+          }
+        }
+      }
+    },
     "No destination chosen yet.": {
       "localizations": {
         "zh-Hans": {
@@ -1363,6 +1393,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有排除任何东西 —— 这些文件夹里的所有文件都会备份。"
+          }
+        }
+      }
+    },
+    "Nothing to back up": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无需备份"
           }
         }
       }
@@ -1893,6 +1933,36 @@
           "stringUnit": {
             "state": "translated",
             "value": "大小"
+          }
+        }
+      }
+    },
+    "Skip backups when nothing has changed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内容没有变化时跳过备份"
+          }
+        }
+      }
+    },
+    "Skip cache folders": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过缓存文件夹"
+          }
+        }
+      }
+    },
+    "Skips folders that apps mark as caches. They are rebuilt automatically, so backing them up costs space and time for nothing.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过被应用标记为缓存的文件夹。这些内容会自动重建，备份它们只会白白占用空间和时间。"
           }
         }
       }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -267,6 +267,16 @@ struct PlanStatusRow: View {
         }
     }
 
+    /// Secondary, not orange or red: nothing is wrong. The plan checked, the
+    /// folders were identical to the last snapshot, and nothing needed
+    /// storing — which is the whole point of the option.
+    private var unchangedLine: some View {
+        Text("No changes — nothing new to back up")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .help(nextRunText)
+    }
+
     private func verificationLine(_ check: CheckRunRecord) -> some View {
         HStack(spacing: 4) {
             Image(systemName: check.success ? "checkmark.shield" : "exclamationmark.shield")
@@ -364,17 +374,28 @@ struct PlanStatusRow: View {
             }
             .help(message)
         case .succeeded(let date):
-            RelativeTimeText(kind: .backedUp, date: date)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .help(nextRunText)
+            // "Backed up just now" would be a lie when the run stored
+            // nothing: the newest snapshot is still the older one, which is
+            // what Restore… will offer (issue #46).
+            if plan.lastRun?.skippedUnchanged == true {
+                unchangedLine
+            } else {
+                RelativeTimeText(kind: .backedUp, date: date)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .help(nextRunText)
+            }
         case .idle:
             if let lastRun = plan.lastRun {
                 if lastRun.success {
-                    RelativeTimeText(kind: .lastBackup, date: lastRun.date)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .help(nextRunText)
+                    if lastRun.skippedUnchanged == true {
+                        unchangedLine
+                    } else {
+                        RelativeTimeText(kind: .lastBackup, date: lastRun.date)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .help(nextRunText)
+                    }
                 } else {
                     Text(lastRun.errorMessage ?? String(localized: "Last backup failed"))
                         .font(.callout)

--- a/Keelhaven/Services/NotificationService.swift
+++ b/Keelhaven/Services/NotificationService.swift
@@ -23,6 +23,18 @@ enum NotificationService {
         await post(content)
     }
 
+    /// A run that stored nothing because the folders were byte-for-byte
+    /// identical to the last backup. Reported separately rather than as
+    /// "0 new files, Zero bytes added", which reads like something went
+    /// wrong — and, more importantly, so nobody is told a snapshot was
+    /// written when none was (issue #46).
+    static func postBackupUnchanged(planName: String) async {
+        let content = UNMutableNotificationContent()
+        content.title = String(localized: "Nothing to back up")
+        content.body = String(localized: "\(planName): no changes since the last backup, so no new snapshot was created.")
+        await post(content)
+    }
+
     static func postBackupFailed(planName: String, message: String) async {
         let content = UNMutableNotificationContent()
         content.title = String(localized: "Backup failed")

--- a/Keelhaven/Services/PlanManager.swift
+++ b/Keelhaven/Services/PlanManager.swift
@@ -16,6 +16,7 @@ struct PlanDraft {
     var checkCadence: CheckCadence = .weekly
     var retention: RetentionPolicy = .off
     var performance: PerformanceOptions = .off
+    var backupOptions: BackupOptions = .off
     /// The wizard's "Start the first backup now" checkbox (issue #42).
     var firstBackupStartsOnCreation: Bool = true
     var password: String
@@ -57,6 +58,7 @@ struct PlanManager {
             checkCadence: draft.checkCadence,
             retention: draft.retention,
             performance: draft.performance,
+            backupOptions: draft.backupOptions,
             firstBackupStartsOnCreation: draft.firstBackupStartsOnCreation
         )
 

--- a/Keelhaven/Support/PlanOptionsDraft.swift
+++ b/Keelhaven/Support/PlanOptionsDraft.swift
@@ -16,6 +16,10 @@ final class PlanOptionsDraft {
     var excludePatterns: [String]
     var checkCadence: CheckCadence
     var retention: RetentionPolicy
+    /// The two boolean `restic backup` switches (issue #46). Off by default,
+    /// like every other advanced setting here.
+    var excludeCaches = false
+    var skipIfUnchanged = false
     /// Scratch field for the exclude-pattern TextField.
     var newExcludePattern = ""
     /// The Advanced knobs are held as text so an empty field can mean
@@ -41,6 +45,8 @@ final class PlanOptionsDraft {
         excludePatterns = plan.excludePatterns
         checkCadence = plan.checkCadence
         retention = plan.retention
+        excludeCaches = plan.backupOptions.excludeCaches
+        skipIfUnchanged = plan.backupOptions.skipIfUnchanged
         newExcludePattern = ""
         uploadLimitText = Self.text(plan.performance.uploadLimitKiBPerSecond)
         readConcurrencyText = Self.text(plan.performance.readConcurrency)
@@ -59,6 +65,10 @@ final class PlanOptionsDraft {
             readConcurrency: Int(readConcurrencyText.trimmingCharacters(in: .whitespaces)),
             packSizeMiB: Int(packSizeText.trimmingCharacters(in: .whitespaces))
         )
+    }
+
+    func builtBackupOptions() -> BackupOptions {
+        BackupOptions(excludeCaches: excludeCaches, skipIfUnchanged: skipIfUnchanged)
     }
 
     func addExcludePattern() {

--- a/Keelhaven/Support/PlanOptionsUI.swift
+++ b/Keelhaven/Support/PlanOptionsUI.swift
@@ -149,6 +149,17 @@ struct ExcludePatternsSection: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                Divider()
+
+                // Lives with the patterns because it is one: a rule about
+                // what not to back up, just one restic already knows by name.
+                Toggle("Skip cache folders", isOn: $options.excludeCaches)
+                    .toggleStyle(.checkbox)
+                Text("Skips folders that apps mark as caches. They are rebuilt automatically, so backing them up costs space and time for nothing.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.top, 6)
         }
@@ -165,6 +176,17 @@ struct AdvancedPerformanceSection: View {
     var body: some View {
         DisclosureGroup("Advanced") {
             VStack(alignment: .leading, spacing: 10) {
+                // Above the intro sentence below, which says "these" and has
+                // to keep referring only to the three numeric fields.
+                Toggle("Skip backups when nothing has changed", isOn: $options.skipIfUnchanged)
+                    .toggleStyle(.checkbox)
+                Text("Creates no new backup when the folders are identical to the last one, instead of a fresh copy that stores nothing. Keeps the list you restore from shorter.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Divider()
+
                 Text("Leave these empty unless a backup is too slow or takes too much of your connection. Empty means restic's own default.")
                     .font(.callout)
                     .foregroundStyle(.secondary)

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -362,6 +362,7 @@ final class WizardModel {
             checkCadence: options.checkCadence,
             retention: options.retention,
             performance: options.builtPerformance(),
+            backupOptions: options.builtBackupOptions(),
             firstBackupStartsOnCreation: firstBackupStartsOnCreation,
             password: password,
             s3SecretKey: destinationType == .s3 ? s3SecretKey : nil,

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Boolean switches handed to `restic backup`. Both are `false` by default,
+/// which leaves the command line exactly as it was before this type existed.
+///
+/// Separate from `PerformanceOptions` on purpose: that type is scoped, in its
+/// own doc comment, to throughput knobs, and all three of its fields are
+/// `Int?`. These change *what gets backed up* and *whether a snapshot is
+/// written* — different question, different type (issue #46).
+///
+/// Every field here must be a flag that leaves restic's `--json` event stream
+/// intact, since the progress UI and every run record are parsed from it.
+/// `--no-scan` is the counter-example and is deliberately not here: it holds
+/// `percent_done` at 0 for the whole run (issue #51).
+public struct BackupOptions: Codable, Hashable, Sendable {
+    /// `--exclude-caches`: skip directories tagged with `CACHEDIR.TAG`.
+    public var excludeCaches: Bool
+    /// `--skip-if-unchanged`: write no snapshot when the content is identical
+    /// to the parent snapshot.
+    ///
+    /// Callers must handle the consequence: restic then omits `snapshot_id`
+    /// from its summary, and reporting that run as an ordinary success would
+    /// tell someone a backup was stored when none was.
+    public var skipIfUnchanged: Bool
+
+    /// Both switches off — restic's own behaviour.
+    public static let off = BackupOptions()
+
+    public init(excludeCaches: Bool = false, skipIfUnchanged: Bool = false) {
+        self.excludeCaches = excludeCaches
+        self.skipIfUnchanged = skipIfUnchanged
+    }
+
+    /// Each field decoded independently with a `false` fallback, so a
+    /// `plans.json` written before any one of them existed still loads. The
+    /// whole-struct fallback lives in `BackupPlan.init(from:)`; this is the
+    /// per-field one, and it is what lets a fourth switch be added later
+    /// without a migration. (`encode(to:)` and `CodingKeys` stay synthesized.)
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            excludeCaches: try container.decodeIfPresent(Bool.self, forKey: .excludeCaches) ?? false,
+            skipIfUnchanged: try container.decodeIfPresent(Bool.self, forKey: .skipIfUnchanged) ?? false
+        )
+    }
+
+    /// True when restic is left entirely to its own behaviour.
+    public var isDefault: Bool {
+        !excludeCaches && !skipIfUnchanged
+    }
+
+    /// The flags for this configuration, empty when nothing is set.
+    /// Both belong to `backup` alone — restic exits with a usage error if
+    /// either appears on `forget`, which is why there is no
+    /// `includingX:`-style parameter here the way `PerformanceOptions` needs.
+    public var arguments: [String] {
+        var args: [String] = []
+        if excludeCaches {
+            args.append("--exclude-caches")
+        }
+        if skipIfUnchanged {
+            args.append("--skip-if-unchanged")
+        }
+        return args
+    }
+}

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
@@ -15,6 +15,8 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
     public var retention: RetentionPolicy
     /// restic throughput knobs, all off by default. See `PerformanceOptions`.
     public var performance: PerformanceOptions
+    /// Boolean `restic backup` switches, both off by default. See `BackupOptions`.
+    public var backupOptions: BackupOptions
     /// Whether the very first backup starts the moment the plan is created,
     /// rather than waiting for the first scheduled time after `createdAt`.
     ///
@@ -46,6 +48,7 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         checkCadence: CheckCadence = .weekly,
         retention: RetentionPolicy = .off,
         performance: PerformanceOptions = .off,
+        backupOptions: BackupOptions = .off,
         firstBackupStartsOnCreation: Bool = true,
         createdAt: Date = Date(),
         lastRun: BackupRunRecord? = nil,
@@ -61,6 +64,7 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         self.checkCadence = checkCadence
         self.retention = retention
         self.performance = performance
+        self.backupOptions = backupOptions
         self.firstBackupStartsOnCreation = firstBackupStartsOnCreation
         self.createdAt = createdAt
         self.lastRun = lastRun
@@ -83,6 +87,7 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         checkCadence = try container.decodeIfPresent(CheckCadence.self, forKey: .checkCadence) ?? .weekly
         retention = try container.decodeIfPresent(RetentionPolicy.self, forKey: .retention) ?? .off
         performance = try container.decodeIfPresent(PerformanceOptions.self, forKey: .performance) ?? .off
+        backupOptions = try container.decodeIfPresent(BackupOptions.self, forKey: .backupOptions) ?? .off
         // Absent on every plan written before this flag existed — and those
         // all started their first backup on creation, so `true` is the value
         // that keeps them behaving exactly as they did.

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupRunRecord.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupRunRecord.swift
@@ -10,6 +10,12 @@ public struct BackupRunRecord: Codable, Hashable, Sendable {
     public var dataAddedBytes: Int64?
     public var duration: TimeInterval?
     public var errorMessage: String?
+    /// True when the run succeeded but wrote no snapshot because the content
+    /// was identical to the parent (`--skip-if-unchanged`). Optional so
+    /// records written before the option existed decode as nil, and read as
+    /// `== true` at every use site — the same shape as
+    /// `PruneRunRecord.blockedByLock`.
+    public var skippedUnchanged: Bool?
 
     public init(
         date: Date,
@@ -19,7 +25,8 @@ public struct BackupRunRecord: Codable, Hashable, Sendable {
         filesChanged: Int? = nil,
         dataAddedBytes: Int64? = nil,
         duration: TimeInterval? = nil,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        skippedUnchanged: Bool? = nil
     ) {
         self.date = date
         self.success = success
@@ -29,5 +36,6 @@ public struct BackupRunRecord: Codable, Hashable, Sendable {
         self.dataAddedBytes = dataAddedBytes
         self.duration = duration
         self.errorMessage = errorMessage
+        self.skippedUnchanged = skippedUnchanged
     }
 }

--- a/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticCommand.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticCommand.swift
@@ -5,7 +5,7 @@ import Foundation
 /// every process on the machine).
 public enum ResticCommand: Equatable, Sendable {
     case initRepository
-    case backup(sources: [String], excludes: [String], tag: String?, performance: PerformanceOptions)
+    case backup(sources: [String], excludes: [String], tag: String?, performance: PerformanceOptions, options: BackupOptions)
     case snapshots
     case stats
     case check
@@ -34,9 +34,10 @@ public enum ResticCommand: Equatable, Sendable {
         switch self {
         case .initRepository:
             return ["init", "--json"]
-        case .backup(let sources, let excludes, let tag, let performance):
+        case .backup(let sources, let excludes, let tag, let performance, let options):
             var args = ["backup", "--json"]
             args.append(contentsOf: performance.arguments(includingReadConcurrency: true))
+            args.append(contentsOf: options.arguments)
             for pattern in excludes {
                 args.append("--exclude")
                 args.append(pattern)

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/Fixtures/backup-skip-if-unchanged.jsonl
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/Fixtures/backup-skip-if-unchanged.jsonl
@@ -1,0 +1,1 @@
+{"message_type":"summary","files_new":0,"files_changed":0,"files_unmodified":2,"dirs_new":0,"dirs_changed":0,"dirs_unmodified":2,"data_blobs":0,"tree_blobs":0,"data_added":0,"data_added_packed":0,"total_files_processed":2,"total_bytes_processed":12,"total_duration":0.720398,"backup_start":"2026-09-08T21:48:03.320608+03:00","backup_end":"2026-09-08T21:48:04.041005+03:00"}

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/IntegrationTestSupport.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/IntegrationTestSupport.swift
@@ -85,7 +85,7 @@ enum IntegrationTestSupport {
 
         var summary: BackupSummary?
         let stream = runner.backupStream(
-            .backup(sources: [sourceURL.path], excludes: [".DS_Store"], tag: "keelhaven-test", performance: .off),
+            .backup(sources: [sourceURL.path], excludes: [".DS_Store"], tag: "keelhaven-test", performance: .off, options: .off),
             destination: destination,
             credentials: credentials
         )

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -148,6 +148,7 @@ final class ModelRoundTripTests: XCTestCase {
         object.removeValue(forKey: "lastPrune")
         object.removeValue(forKey: "performance")
         object.removeValue(forKey: "firstBackupStartsOnCreation")
+        object.removeValue(forKey: "backupOptions")
         let legacyData = try JSONSerialization.data(withJSONObject: object)
 
         let decoder = JSONDecoder()
@@ -161,6 +162,7 @@ final class ModelRoundTripTests: XCTestCase {
         // Every plan written before the flag existed did start its first
         // backup on creation, so absence must decode as true (issue #42).
         XCTAssertTrue(decoded.firstBackupStartsOnCreation)
+        XCTAssertEqual(decoded.backupOptions, .off)
         XCTAssertEqual(decoded.name, plan.name)
         XCTAssertEqual(decoded.schedule, plan.schedule)
     }
@@ -200,5 +202,63 @@ final class ModelRoundTripTests: XCTestCase {
         XCTAssertEqual(decoded.readConcurrency, 32)
         XCTAssertEqual(decoded.packSizeMiB, 4)
         XCTAssertNil(decoded.uploadLimitKiBPerSecond)
+    }
+
+    /// A `plans.json` holding only one of the two switches — the shape a
+    /// future third switch (#50) will create for anyone upgrading. Each field
+    /// falls back independently, so no migration is ever needed.
+    func testBackupOptionsDecodesMissingFieldsAsFalse() throws {
+        let decoder = JSONDecoder()
+
+        let partial = try XCTUnwrap(#"{"excludeCaches":true}"#.data(using: .utf8))
+        let decodedPartial = try decoder.decode(BackupOptions.self, from: partial)
+        XCTAssertTrue(decodedPartial.excludeCaches)
+        XCTAssertFalse(decodedPartial.skipIfUnchanged)
+
+        let empty = try XCTUnwrap("{}".data(using: .utf8))
+        XCTAssertEqual(try decoder.decode(BackupOptions.self, from: empty), .off)
+    }
+
+    func testBackupOptionsRoundTrip() throws {
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .hourly,
+            backupOptions: BackupOptions(excludeCaches: true, skipIfUnchanged: true),
+            createdAt: date
+        )
+        let decoded = try roundTrip(plan)
+        XCTAssertTrue(decoded.backupOptions.excludeCaches)
+        XCTAssertTrue(decoded.backupOptions.skipIfUnchanged)
+        XCTAssertFalse(decoded.backupOptions.isDefault)
+    }
+
+    /// The skipped-run marker survives a save/load, so the menu bar still
+    /// says "no changes" after a relaunch instead of reverting to
+    /// "Last backup ... ago" (issue #46).
+    func testSkippedUnchangedSurvivesRoundTrip() throws {
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .hourly,
+            createdAt: date,
+            lastRun: BackupRunRecord(date: date, success: true, skippedUnchanged: true)
+        )
+        XCTAssertEqual(try roundTrip(plan).lastRun?.skippedUnchanged, true)
+    }
+
+    /// Records written before the option existed have no such key and must
+    /// read as "not skipped", not as a missing-value crash.
+    func testLegacyRunRecordHasNoSkippedMarker() throws {
+        let legacy = try XCTUnwrap(
+            #"{"date":"2026-08-14T22:20:53Z","success":true}"#.data(using: .utf8)
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let record = try decoder.decode(BackupRunRecord.self, from: legacy)
+        XCTAssertNil(record.skippedUnchanged)
+        XCTAssertNotEqual(record.skippedUnchanged, true)
     }
 }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
@@ -11,7 +11,8 @@ final class ResticCommandTests: XCTestCase {
             sources: ["/Users/me/Documents", "/Users/me/Photos"],
             excludes: [".DS_Store", "node_modules"],
             tag: "keelhaven",
-            performance: .off
+            performance: .off,
+            options: .off
         )
         XCTAssertEqual(command.arguments, [
             "backup", "--json",
@@ -23,7 +24,7 @@ final class ResticCommandTests: XCTestCase {
     }
 
     func testBackupWithoutTagOrExcludes() {
-        let command = ResticCommand.backup(sources: ["/tmp/data"], excludes: [], tag: nil, performance: .off)
+        let command = ResticCommand.backup(sources: ["/tmp/data"], excludes: [], tag: nil, performance: .off, options: .off)
         XCTAssertEqual(command.arguments, ["backup", "--json", "/tmp/data"])
     }
 
@@ -78,7 +79,8 @@ final class ResticCommandTests: XCTestCase {
                 uploadLimitKiBPerSecond: 500,
                 readConcurrency: 8,
                 packSizeMiB: 64
-            )
+            ),
+            options: .off
         )
         // Flags come before the sources: restic accepts them either way, but
         // a path is a positional argument and reads as one here.
@@ -89,6 +91,45 @@ final class ResticCommandTests: XCTestCase {
             "--pack-size", "64",
             "/tmp/data",
         ])
+    }
+
+    func testBackupOptionsArguments() {
+        XCTAssertEqual(BackupOptions.off.arguments, [])
+        XCTAssertTrue(BackupOptions.off.isDefault)
+        XCTAssertEqual(BackupOptions(excludeCaches: true).arguments, ["--exclude-caches"])
+        XCTAssertEqual(BackupOptions(skipIfUnchanged: true).arguments, ["--skip-if-unchanged"])
+        XCTAssertFalse(BackupOptions(excludeCaches: true).isDefault)
+        XCTAssertFalse(BackupOptions(skipIfUnchanged: true).isDefault)
+    }
+
+    /// Both switches land between the throughput flags and the excludes, and
+    /// ahead of the positional sources — the order this test exists to pin.
+    func testBackupCarriesEveryBackupOption() {
+        let command = ResticCommand.backup(
+            sources: ["/tmp/data"],
+            excludes: ["*.log"],
+            tag: "keelhaven",
+            performance: PerformanceOptions(packSizeMiB: 64),
+            options: BackupOptions(excludeCaches: true, skipIfUnchanged: true)
+        )
+        XCTAssertEqual(command.arguments, [
+            "backup", "--json",
+            "--pack-size", "64",
+            "--exclude-caches",
+            "--skip-if-unchanged",
+            "--exclude", "*.log",
+            "--tag", "keelhaven",
+            "/tmp/data",
+        ])
+    }
+
+    /// Neither switch may reach `forget`: restic exits with a usage error on
+    /// an unknown flag, which would break every retention pass. `.forget`
+    /// takes no `BackupOptions` at all, so this pins that it stays that way.
+    func testForgetCarriesNoBackupOptions() {
+        let command = ResticCommand.forget(retention: .month, performance: .off)
+        XCTAssertFalse(command.arguments.contains("--exclude-caches"))
+        XCTAssertFalse(command.arguments.contains("--skip-if-unchanged"))
     }
 
     /// `--read-concurrency` is a `backup` flag. Passing it to `forget` makes

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticMessageParsingTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticMessageParsingTests.swift
@@ -23,6 +23,48 @@ final class ResticMessageParsingTests: XCTestCase {
         XCTAssertTrue(result.repository.hasSuffix("/repo"))
     }
 
+    /// The `--skip-if-unchanged` run that stored nothing. Captured from real
+    /// restic 0.19.1 by backing the same unchanged source up twice; this is
+    /// the second run.
+    ///
+    /// The point of the fixture is the *absence* of `snapshot_id` — restic's
+    /// scripting docs say it "is omitted if snapshot creation was skipped",
+    /// and this pins that we decode that shape without losing the rest of the
+    /// summary, which is what the run record and the notification read.
+    func testDecodeSkippedSnapshotSummary() throws {
+        let lines = try fixtureLines("backup-skip-if-unchanged.jsonl")
+        XCTAssertEqual(lines.count, 1)
+
+        let event = try XCTUnwrap(ResticJSON.decodeProgressEvent(fromLine: lines[0]))
+        guard case .summary(let summary) = event else {
+            return XCTFail("Expected a summary event")
+        }
+        XCTAssertNil(summary.snapshotID)
+        XCTAssertEqual(summary.filesNew, 0)
+        XCTAssertEqual(summary.filesChanged, 0)
+        XCTAssertEqual(summary.filesUnmodified, 2)
+        XCTAssertEqual(summary.dataAdded, 0)
+        XCTAssertEqual(summary.totalFilesProcessed, 2)
+        XCTAssertNotNil(summary.totalDuration)
+        XCTAssertNotNil(summary.backupStart)
+    }
+
+    /// The same summary shape when a snapshot *was* written, so the two
+    /// fixtures together show that `snapshot_id` is the only difference —
+    /// which is what `AppState` keys its "nothing was stored" reporting on.
+    func testSnapshotIDIsThePresentDifferenceFromASkippedRun() throws {
+        let skipped = try fixtureLines("backup-skip-if-unchanged.jsonl")[0]
+        let stored = try fixtureLines("backup-incremental.jsonl")[0]
+
+        guard case .summary(let skippedSummary)? = ResticJSON.decodeProgressEvent(fromLine: skipped),
+              case .summary(let storedSummary)? = ResticJSON.decodeProgressEvent(fromLine: stored)
+        else {
+            return XCTFail("Expected both fixtures to decode as summaries")
+        }
+        XCTAssertNil(skippedSummary.snapshotID)
+        XCTAssertNotNil(storedSummary.snapshotID)
+    }
+
     func testDecodeEveryBackupProgressLine() throws {
         let lines = try fixtureLines("backup-progress.jsonl")
         XCTAssertEqual(lines.count, 10)

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -48,7 +48,7 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         // streaming backup: must yield exactly one summary carrying a snapshot id
         var summary: BackupSummary?
         let stream = runner.backupStream(
-            .backup(sources: [sourceURL.path], excludes: [".DS_Store"], tag: "keelhaven-test", performance: .off),
+            .backup(sources: [sourceURL.path], excludes: [".DS_Store"], tag: "keelhaven-test", performance: .off, options: .off),
             destination: destination,
             credentials: credentials
         )
@@ -194,7 +194,7 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         )
         // A snapshot, so the retention pass below has something real to do.
         for try await _ in runner.backupStream(
-            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: .off),
+            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: .off, options: .off),
             destination: destination,
             credentials: credentials
         ) {}
@@ -254,7 +254,7 @@ final class ResticRunnerIntegrationTests: XCTestCase {
 
         // Backups are unaffected — the reason this failure hides so well.
         for try await _ in runner.backupStream(
-            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: .off),
+            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: .off, options: .off),
             destination: destination,
             credentials: credentials
         ) {}
@@ -339,7 +339,7 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         )
         var summary: BackupSummary?
         let stream = runner.backupStream(
-            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: performance),
+            .backup(sources: [sourceURL.path], excludes: [], tag: "keelhaven-test", performance: performance, options: .off),
             destination: destination,
             credentials: credentials
         )
@@ -357,5 +357,153 @@ final class ResticRunnerIntegrationTests: XCTestCase {
             destination: destination,
             credentials: credentials
         )
+    }
+
+    /// `--exclude-caches` against the real binary: a directory carrying a
+    /// `CACHEDIR.TAG` must not reach the snapshot. Asserted by restoring the
+    /// snapshot and looking, not by trusting the summary counts — the counts
+    /// would also look right if restic silently ignored the flag.
+    func testExcludeCachesSkipsTaggedDirectories() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let repoURL = workDirectory.appendingPathComponent("repo", isDirectory: true)
+        let sourceURL = workDirectory.appendingPathComponent("src", isDirectory: true)
+        let cacheURL = sourceURL.appendingPathComponent("Cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheURL, withIntermediateDirectories: true)
+        try Data("keep me\n".utf8).write(to: sourceURL.appendingPathComponent("keep.txt"))
+        try Data("junk\n".utf8).write(to: cacheURL.appendingPathComponent("junk.bin"))
+        // The exact marker the Cache Directory Tagging Standard defines.
+        try Data("Signature: 8a477f597d28d172789f06886806bc55\n".utf8)
+            .write(to: cacheURL.appendingPathComponent("CACHEDIR.TAG"))
+
+        let destination = Destination.local(path: repoURL.path)
+        let credentials = RepoCredentials(repositoryPassword: "integration-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+
+        var summary: BackupSummary?
+        let stream = runner.backupStream(
+            .backup(
+                sources: [sourceURL.path],
+                excludes: [],
+                tag: "keelhaven-test",
+                performance: .off,
+                options: BackupOptions(excludeCaches: true)
+            ),
+            destination: destination,
+            credentials: credentials
+        )
+        for try await event in stream {
+            if case .summary(let value) = event { summary = value }
+        }
+        let snapshotID = try XCTUnwrap(summary?.snapshotID)
+
+        let targetURL = workDirectory.appendingPathComponent("restored", isDirectory: true)
+        try await runner.runIgnoringOutput(
+            .restore(snapshotID: snapshotID, target: targetURL.path),
+            destination: destination,
+            credentials: credentials
+        )
+
+        let restoredRoot = targetURL.appendingPathComponent(sourceURL.path)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: restoredRoot.appendingPathComponent("keep.txt").path),
+            "The untagged file should have been backed up"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: restoredRoot.appendingPathComponent("Cache/junk.bin").path),
+            "A CACHEDIR.TAG directory should have been excluded"
+        )
+    }
+
+    /// `--skip-if-unchanged` against the real binary, twice over an untouched
+    /// source. Pins the two things the app depends on: the second run creates
+    /// no snapshot, and its summary omits `snapshot_id` — which is the only
+    /// signal `AppState` has for reporting "nothing was stored" (issue #46).
+    ///
+    /// Not run from `workDirectory`. That lives under `$TMPDIR`, which macOS
+    /// writes to constantly, and restic stores the **whole ancestor chain** in
+    /// the snapshot tree — so one unrelated process creating a temp file makes
+    /// the second snapshot differ even though no backed-up file did.
+    /// Confirmed with `restic diff`: 0 files and 0 dirs changed, 5 tree blobs
+    /// replaced, and `restic ls --long` showing only `$TMPDIR`'s own mtime
+    /// moving. `/private/tmp` is quiet enough that this does not happen; if it
+    /// does anyway, the test skips rather than failing on someone else's write.
+    func testSkipIfUnchangedOmitsSnapshotIDOnTheSecondRun() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let root = URL(fileURLWithPath: "/tmp").resolvingSymlinksInPath()
+            .appendingPathComponent("KeelhavenSkipIfUnchanged-\(UUID().uuidString)", isDirectory: true)
+        let sourceURL = root.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("unchanging\n".utf8).write(to: sourceURL.appendingPathComponent("a.txt"))
+
+        let destination = Destination.local(path: root.appendingPathComponent("repo").path)
+        let credentials = RepoCredentials(repositoryPassword: "integration-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+
+        func backup() async throws -> BackupSummary? {
+            var summary: BackupSummary?
+            let stream = runner.backupStream(
+                .backup(
+                    sources: [sourceURL.path],
+                    excludes: [],
+                    tag: "keelhaven-test",
+                    performance: .off,
+                    options: BackupOptions(skipIfUnchanged: true)
+                ),
+                destination: destination,
+                credentials: credentials
+            )
+            for try await event in stream {
+                if case .summary(let value) = event { summary = value }
+            }
+            return summary
+        }
+
+        let firstSummary = try await backup()
+        let first = try XCTUnwrap(firstSummary)
+        XCTAssertNotNil(first.snapshotID, "The first run must create a snapshot")
+
+        let secondSummary = try await backup()
+        let second = try XCTUnwrap(secondSummary)
+
+        // True whether or not a snapshot was written: nothing in the source
+        // moved. A regression that stopped passing the flag, or broke exclude
+        // handling, would fail here rather than reaching the skip below.
+        XCTAssertEqual(second.filesNew, 0)
+        XCTAssertEqual(second.filesChanged, 0)
+        XCTAssertEqual(second.filesUnmodified, 1)
+
+        if second.snapshotID != nil {
+            throw XCTSkip(
+                "A directory above the source changed while the test ran, so the "
+                + "snapshot legitimately differed. Nothing in the source did."
+            )
+        }
+
+        let snapshots = try await runner.run(
+            .snapshots,
+            destination: destination,
+            credentials: credentials,
+            decoding: [ResticSnapshot].self
+        )
+        XCTAssertEqual(snapshots.count, 1)
     }
 }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerProcessTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerProcessTests.swift
@@ -92,7 +92,7 @@ final class ResticRunnerProcessTests: XCTestCase {
             binaryURL: workDirectory.appendingPathComponent("does-not-exist")
         )
         let stream = runner.backupStream(
-            .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off),
+            .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off, options: .off),
             destination: destination, credentials: credentials
         )
         do {
@@ -114,7 +114,7 @@ final class ResticRunnerProcessTests: XCTestCase {
         """)
         let runner = ResticRunner(binaryURL: binary)
         let stream = runner.backupStream(
-            .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off),
+            .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off, options: .off),
             destination: destination, credentials: credentials
         )
 
@@ -142,7 +142,7 @@ final class ResticRunnerProcessTests: XCTestCase {
 
         let consumer = Task {
             let stream = runner.backupStream(
-                .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off),
+                .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off, options: .off),
                 destination: destination, credentials: credentials
             )
             var count = 0
@@ -182,7 +182,7 @@ final class ResticRunnerProcessTests: XCTestCase {
 
         let consumer = Task {
             let stream = runner.backupStream(
-                .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off),
+                .backup(sources: ["/tmp"], excludes: [], tag: nil, performance: .off, options: .off),
                 destination: destination, credentials: credentials
             )
             var count = 0


### PR DESCRIPTION
Fixes #46

Branched from `main` at 8d6c4f5.

## Why this one

Two users arriving from command-line restic asked for both flags independently — the strongest signal #45 has produced. It also unblocks #50 and #51, which both need somewhere for a boolean backup option to live.

## `BackupOptions`

New struct in Core rather than more fields on `PerformanceOptions`: that type's own doc comment scopes it to throughput and all three of its fields are `Int?`. Each field here decodes independently with a `false` fallback, so #50's third switch needs no migration. `BackupPlan.backupOptions` sits behind `decodeIfPresent … ?? .off`, and `ResticCommand.backup` renders the flags next to the performance ones.

## `--skip-if-unchanged` needed more than a flag

When restic stores nothing it **omits `snapshot_id`** from the summary. Reporting that as an ordinary success would tell someone a backup was written when none was — and the newest snapshot is still the older one, which is what *Restore…* will offer them.

So the run record carries the fact, the row says *"No changes — nothing new to back up"* both live and after a relaunch, and the notification says the same instead of *"0 new files, Zero bytes added"*. The nil check is only trusted when we asked for the option: the same field is also absent from the nested summary in `restic snapshots --json`, so a bare nil check is ambiguous anywhere else.

## Design

Per the product principles, both default to **off** — an untouched plan produces exactly the arguments it did before. *Skip cache folders* sits with the exclude patterns because it is one; *Skip backups when nothing has changed* sits under Advanced, above the "leave these empty" sentence so that sentence still refers only to the three numeric fields. Neither uses a restic flag name in its label.

Both live in the views #48 made shared, so one definition puts them in the wizard's *Customize this plan* **and** in Edit Plan — which matters here, since `--exclude-caches` is exactly what you want set before the first backup runs.

## Verification

Against **real restic 0.19.1**, not just argument assembly:

- `--exclude-caches` — asserted by restoring the snapshot and looking for the `CACHEDIR.TAG` directory, not by trusting summary counts, which would look right even if restic ignored the flag.
- `--skip-if-unchanged` — an untouched source backed up twice: first run creates a snapshot, second omits `snapshot_id`, repository holds one snapshot.
- Fixture `backup-skip-if-unchanged.jsonl` is the real skipping run, captured unmodified per the repo rule.
- 146 tests pass, 3 skipped (network backends unreachable locally). Line coverage stays 100% on KeelhavenCore; `BackupOptions.swift` is 100%.
- Localization cross-checked against Xcode's extracted `.stringsdata`, not by eye — the notification key really is `%@: no changes…`, and all seven new strings ship with Simplified Chinese.

### One finding worth knowing

The skip test deliberately does **not** run from `$TMPDIR`. restic stores the **whole ancestor chain** in the snapshot tree, so one unrelated process touching `$TMPDIR` makes the second snapshot differ even though nothing in the source did. `restic diff` showed 0 files and 0 dirs changed with 5 tree blobs replaced, and `restic ls --long` showed only `$TMPDIR`'s own mtime moving. The test runs from `/private/tmp` and self-skips, rather than failing, if the chain moves anyway — it still asserts `filesNew == 0 && filesChanged == 0` first, so a real regression fails instead of skipping.

This is also a user-facing property: home-directory churn can defeat the option. It errs toward creating a snapshot that stores nothing, never toward missing a backup, so the copy stays simple rather than explaining ancestor mtimes.

## UI verified

Both checkboxes screenshotted in **Edit Plan**, in English and Simplified Chinese, with a plan seeded as `{"excludeCaches": true, "skipIfUnchanged": true}` in `plans.json` — so the shots also prove the decoding path, not just the layout:

- *Skip cache folders* / 跳过缓存文件夹 — checked, sitting below the exclude patterns and their divider, with its explanation.
- *Skip backups when nothing has changed* / 内容没有变化时跳过备份 — checked, at the top of Advanced, above the "leave these empty" sentence so that sentence still refers only to the three numeric fields.

Not separately screenshotted in the wizard: both render through `ExcludePatternsSection` and `AdvancedPerformanceSection`, the same two views the wizard's *Customize this plan* renders (`ScheduleStepView.swift:101-102`, `EditPlanWindowView.swift:70-72`), whose placement in both windows was screenshotted in #48.
