### PR TITLE
Tell Backblaze B2 users about the lifecycle rule, in the wizard and the FAQ

### DIFF
--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -334,6 +334,16 @@
         }
       }
     },
+    "Backblaze B2 keeps a hidden copy of everything a backup deletes, and keeps charging for it. Turn on the bucket's “Keep only the last version of the file” lifecycle rule so B2 clears them. [Why this is needed](https://keelhaven.app/#faq)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backblaze B2 会为备份删掉的每一样东西保留一份隐藏副本，并持续计费。请在存储桶上打开「Keep only the last version of the file」生命周期规则，让 B2 清理它们。[为什么需要这样做](https://keelhaven.app/zh/#faq)"
+          }
+        }
+      }
+    },
     "Backed up": {
       "localizations": {
         "zh-Hans": {

--- a/Keelhaven/Wizard/DestinationStepView.swift
+++ b/Keelhaven/Wizard/DestinationStepView.swift
@@ -218,6 +218,17 @@ struct DestinationStepView: View {
             }
             .formStyle(.columns)
             .textFieldStyle(.roundedBorder)
+            // Plain secondary text, like the SFTP note below and unlike the
+            // HintCallout boxes above: nothing the user typed is wrong. It is
+            // a standing fact about B2 that no other S3 provider shares, and
+            // one Keelhaven cannot fix from this side — `forget --prune`
+            // deletes through the S3 API, which on B2 only hides (issue #47).
+            if model.destinationIsBackblazeB2 {
+                Text("Backblaze B2 keeps a hidden copy of everything a backup deletes, and keeps charging for it. Turn on the bucket's “Keep only the last version of the file” lifecycle rule so B2 clears them. [Why this is needed](https://keelhaven.app/#faq)")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             if !model.destinationFieldsComplete {
                 Text("All fields except the path prefix are required.")
                     .font(.callout)

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -189,6 +189,20 @@ final class WizardModel {
         }
     }
 
+    /// The endpoint being typed is Backblaze B2, which needs a bucket-side
+    /// lifecycle rule or deleted data keeps being billed forever (issue #47).
+    /// Guidance, not a conflict: the destination is perfectly valid, so this
+    /// deliberately has no effect on `destinationHasConflict` or on Next.
+    var destinationIsBackblazeB2: Bool {
+        guard destinationType == .s3 else { return false }
+        return S3Config(
+            endpoint: s3Endpoint,
+            bucket: s3Bucket,
+            pathPrefix: s3Prefix,
+            accessKeyID: s3AccessKey
+        ).isBackblazeB2
+    }
+
     /// A REST URL pasted with restic-docs-style embedded credentials
     /// ("https://user:pass@host/"). Refused because the URL is persisted to
     /// plans.json in plain text — the separate fields keep the password in

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/Destination.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/Destination.swift
@@ -54,6 +54,35 @@ public struct S3Config: Codable, Hashable, Sendable {
         self.accessKeyID = accessKeyID
     }
 
+    /// True when the endpoint points at Backblaze B2's S3-compatible API.
+    ///
+    /// B2 needs one thing no other S3 provider does: deleting an object
+    /// through the S3 API only *hides* it there, so every version restic
+    /// removes keeps costing money until a bucket lifecycle rule clears it —
+    /// something `forget --prune` can never do from this side (issue #47).
+    /// The wizard uses this to say so while the endpoint is being typed.
+    ///
+    /// Matched on the host suffix rather than by `contains`, so a bucket or
+    /// a self-hosted endpoint that merely mentions the name — say
+    /// `minio.backblazeb2.com.example.net` — is not mistaken for B2. Any
+    /// scheme, port, path or trailing dot is stripped first.
+    public var isBackblazeB2: Bool {
+        var host = endpoint.lowercased()
+        if let schemeRange = host.range(of: "://") {
+            host = String(host[schemeRange.upperBound...])
+        }
+        host = String(host.prefix { $0 != "/" })
+        // Strip credentials and port: "user@host:9000" -> "host".
+        if let at = host.lastIndex(of: "@") {
+            host = String(host[host.index(after: at)...])
+        }
+        host = String(host.prefix { $0 != ":" })
+        while host.hasSuffix(".") {
+            host.removeLast()
+        }
+        return host == "backblazeb2.com" || host.hasSuffix(".backblazeb2.com")
+    }
+
     public var repositoryLocation: String {
         var endpointWithScheme = endpoint
         if !endpointWithScheme.contains("://") {

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/EdgeCaseTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/EdgeCaseTests.swift
@@ -121,3 +121,45 @@ final class StoreEdgeTests: XCTestCase {
         XCTAssertTrue(deletedRecords.isEmpty)
     }
 }
+
+/// `S3Config.isBackblazeB2` decides whether the wizard warns that deleted
+/// data keeps being billed until a bucket lifecycle rule clears it (issue
+/// #47). A false negative costs someone money silently; a false positive
+/// tells them to change a setting that does not exist on their provider.
+final class BackblazeB2DetectionTests: XCTestCase {
+    private func config(_ endpoint: String) -> S3Config {
+        S3Config(endpoint: endpoint, bucket: "b", pathPrefix: "", accessKeyID: "k")
+    }
+
+    func testRecognisesBackblazeEndpoints() {
+        // The form B2's own console shows, plus the shapes people paste.
+        XCTAssertTrue(config("s3.us-west-004.backblazeb2.com").isBackblazeB2)
+        XCTAssertTrue(config("s3.eu-central-003.backblazeb2.com").isBackblazeB2)
+        XCTAssertTrue(config("https://s3.us-west-004.backblazeb2.com").isBackblazeB2)
+        XCTAssertTrue(config("https://s3.us-west-004.backblazeb2.com/").isBackblazeB2)
+        XCTAssertTrue(config("S3.US-WEST-004.BackblazeB2.com").isBackblazeB2)
+        XCTAssertTrue(config("backblazeb2.com").isBackblazeB2)
+        XCTAssertTrue(config("s3.us-west-004.backblazeb2.com:443").isBackblazeB2)
+        // A trailing dot is a valid fully-qualified host.
+        XCTAssertTrue(config("s3.us-west-004.backblazeb2.com.").isBackblazeB2)
+    }
+
+    func testDoesNotMistakeOtherProvidersForBackblaze() {
+        XCTAssertFalse(config("s3.amazonaws.com").isBackblazeB2)
+        XCTAssertFalse(config("s3.wasabisys.com").isBackblazeB2)
+        XCTAssertFalse(config("minio.example.com:9000").isBackblazeB2)
+        XCTAssertFalse(config("").isBackblazeB2)
+        // The suffix check exists for these: the name appears, the host is
+        // somebody else's.
+        XCTAssertFalse(config("minio.backblazeb2.com.example.net").isBackblazeB2)
+        XCTAssertFalse(config("notbackblazeb2.com").isBackblazeB2)
+        XCTAssertFalse(config("https://example.com/backblazeb2.com").isBackblazeB2)
+    }
+
+    /// Credentials in the endpoint must not hide the host behind them.
+    func testStripsCredentialsBeforeMatching() {
+        XCTAssertTrue(config("https://key@s3.us-west-004.backblazeb2.com").isBackblazeB2)
+        XCTAssertFalse(config("https://s3.us-west-004.backblazeb2.com@evil.example.com").isBackblazeB2)
+    }
+}
+

--- a/site/index.md
+++ b/site/index.md
@@ -240,6 +240,15 @@ No. Backups are encrypted on your Mac before anything is uploaded, and the repos
 An external or network drive mounted on your Mac, any S3-compatible bucket (AWS, Backblaze B2, Wasabi, Cloudflare R2, MinIO), SFTP to your own server or NAS, and a [restic REST server](https://github.com/restic/rest-server) you host yourself.
 
 </FaqItem>
+<FaqItem question="I back up to Backblaze B2. Why is deleting old backups not freeing any space?">
+
+Because B2 does not delete — it hides. Keelhaven reaches B2 through its S3-compatible API, and deleting an object over that API marks the old version hidden rather than removing it. Hidden versions still take up storage and still appear on your bill, and no amount of `restic forget --prune` can reach them: the deletion has already been issued, and it did what the API allows.
+
+The fix is one setting on the bucket, not in Keelhaven. In your B2 bucket's lifecycle settings, choose **Keep only the last version of the file**. This is what [restic's own documentation](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html) recommends for B2, and it describes what follows: the previous version of the file is "hidden" for one day and then deleted automatically by B2.
+
+Expect the space to come back over the next day or two rather than straight away. B2 applies lifecycle rules on its own schedule, so a bucket that looks unchanged tomorrow morning is normal — not a sign the rule failed.
+
+</FaqItem>
 <FaqItem question="Do backups grow forever?">
 
 Only if you leave retention off — which is the default, because deleting your data is never something Keelhaven decides on its own. Every run adds a deduplicated snapshot, storing only what changed. When a plan should stop growing, pick a retention preset in Edit Plan — a year of history or a month of history — and older snapshots are thinned to daily, weekly and monthly keepers, with the space reclaimed after a backup at most once a week. The repository stays standard restic throughout, so `restic forget --prune` with a policy of your own still works from any machine.

--- a/site/zh/index.md
+++ b/site/zh/index.md
@@ -262,6 +262,15 @@ Beta 版还没做 Apple 公证，第一次打开要多点一次确认，[下面�
 挂在 Mac 上的外置硬盘或网络硬盘；任何兼容 S3 的存储桶（AWS、Backblaze B2、Wasabi、Cloudflare R2、MinIO）；用 SFTP 连自己的服务器或 NAS；以及你自己架设的 [restic REST server](https://github.com/restic/rest-server)。
 
 </FaqItem>
+<FaqItem question="我备份到 Backblaze B2，为什么删掉旧备份并没有腾出空间？">
+
+因为 B2 不是删除，而是隐藏。Keelhaven 通过 B2 的 S3 兼容 API 访问它，而经由这个 API 删除对象，只会把旧版本标记为隐藏，并不会真正移除。隐藏的版本照样占用存储、照样出现在账单上，而且 `restic forget --prune` 再跑多少次也够不着它们——删除指令早就发出去了，它已经做完了这个 API 允许它做的事。
+
+解法是存储桶上的一个设置，不在 Keelhaven 里。在 B2 存储桶的生命周期设置中选择 **Keep only the last version of the file**（只保留文件的最新版本）。这正是 [restic 官方文档](https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html)对 B2 的建议，文档里也写明了之后会发生什么：文件的旧版本会被「隐藏」一天，然后由 B2 自动删除。
+
+空间通常会在随后一两天内回来，而不是立刻。B2 按它自己的节奏执行生命周期规则，所以第二天早上看桶还没什么变化是正常的，并不代表规则没生效。
+
+</FaqItem>
 <FaqItem question="备份会一直涨下去吗？">
 
 默认会，因为删你的数据这件事，Keelhaven 从不自作主张。每次运行加一个去重后的快照，只存变化的部分。想让某个计划别再涨，在「编辑计划」里选一档保留策略，保留一年或保留一个月，较旧的快照就会按每日、每周、每月逐级精简，空间在备份完成后回收，每周最多清一次。仓库始终是标准 restic 格式，想自己用 `restic forget --prune` 按别的策略清，随时可以。


### PR DESCRIPTION
Fixes #47

Branched from `main` at c9f55fe.

## The problem

Backing up to B2 through its S3-compatible API costs money forever, silently. restic deletes objects over that API without naming a version, which on B2 only **hides** them — hidden versions keep taking storage and appearing on the bill, and no amount of `restic forget --prune` can reach them, because the deletion already did everything the API allows.

The fix is a bucket-side lifecycle rule, **Keep only the last version of the file**. Nothing in the app or on the site said so.

## What changed

**FAQ, both languages** — a new entry after "Which destinations are supported?" in `site/index.md` and `site/zh/index.md`, explaining that B2 hides rather than deletes, naming the rule, and quoting restic's own documentation.

**Wizard hint** — shown in the S3 form while the endpoint is being typed, which is where the person is when the decision is theirs to make. It carries the action in one sentence plus a link to the FAQ (the Chinese string links to `/zh/#faq`).

## Two judgement calls worth reviewing

**It is plain secondary text, not a `HintCallout`.** The issue asked for "a single line of guidance", and `HintCallout`'s own doc comment reserves the tinted box for problems — an orange box while someone types a perfectly valid endpoint reads as an accusation. It sits with the SFTP note ("Uses your existing SSH keys…"), which is the same kind of standing fact about a backend. It also stays out of `destinationHasConflict`, so it never blocks **Next**. If you would rather it were a warning box, that is a one-line change.

**On the numbers.** Following the caution recorded on the issue: the FAQ says **one day**, quoting restic's wording, and sets the expectation that space comes back over the following day or two because B2 runs lifecycle rules on its own schedule. It deliberately does **not** repeat the "two days from upload" figure the reporter found — that describes a rule expiring *current* versions, and by the time B2 looks, restic has already hidden the object. Writing it would send people to configure `daysFromUploadingToHiding`, which is not what they want.

## Detection

`S3Config.isBackblazeB2` lives in Core so it can be tested. It matches the **host suffix**, not `contains`: a false negative costs someone money silently, and a false positive sends every other S3 user hunting for a setting their provider does not have. Scheme, credentials, port, path and a trailing dot are stripped first.

## Verification

- **149 tests, 0 failures.** 12 new assertions across 3 cases covering the endpoint shapes B2 hands out (`s3.us-west-004.backblazeb2.com`, with scheme, uppercase, port, trailing dot) and the ones that must **not** match — `s3.amazonaws.com`, `s3.wasabisys.com`, `minio.example.com:9000`, `notbackblazeb2.com`, `minio.backblazeb2.com.example.net`, and a credential-stuffed `…backblazeb2.com@evil.example.com`. Line coverage stays 100% on KeelhavenCore.
- **`npm --prefix site run build`** passes; both language files carry 15 FAQ entries, so the mirror stayed in step.
- **Runtime, real build on an isolated `HOME`:** with `s3.us-west-004.backblazeb2.com` the hint appears in English and Simplified Chinese with the link rendering as a link; with `s3.amazonaws.com` it is absent and the form reads exactly as it did before.
- Localization cross-checked against Xcode's extracted `.stringsdata` rather than by eye.