### PR TITLE
Add `--one-file-system` as a named backup option

### DIFF
--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -824,6 +824,16 @@
         }
       }
     },
+    "Don't back up other disks mounted inside these folders": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不要备份挂载在这些文件夹里的其它磁盘"
+          }
+        }
+      }
+    },
     "Done": {
       "localizations": {
         "zh-Hans": {
@@ -2003,6 +2013,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "第 %1$lld 步，共 %2$lld 步：%3$@"
+          }
+        }
+      }
+    },
+    "Stops at the disk each folder lives on. Without this, an external drive or a network share mounted inside one of them is backed up too.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只备份到每个文件夹所在的那块磁盘为止。不勾选时，挂载在其中的外置硬盘或网络共享也会一并被备份。"
           }
         }
       }

--- a/Keelhaven/Support/PlanOptionsDraft.swift
+++ b/Keelhaven/Support/PlanOptionsDraft.swift
@@ -19,6 +19,7 @@ final class PlanOptionsDraft {
     /// The two boolean `restic backup` switches (issue #46). Off by default,
     /// like every other advanced setting here.
     var excludeCaches = false
+    var oneFileSystem = false
     var skipIfUnchanged = false
     /// Scratch field for the exclude-pattern TextField.
     var newExcludePattern = ""
@@ -46,6 +47,7 @@ final class PlanOptionsDraft {
         checkCadence = plan.checkCadence
         retention = plan.retention
         excludeCaches = plan.backupOptions.excludeCaches
+        oneFileSystem = plan.backupOptions.oneFileSystem
         skipIfUnchanged = plan.backupOptions.skipIfUnchanged
         newExcludePattern = ""
         uploadLimitText = Self.text(plan.performance.uploadLimitKiBPerSecond)
@@ -68,7 +70,11 @@ final class PlanOptionsDraft {
     }
 
     func builtBackupOptions() -> BackupOptions {
-        BackupOptions(excludeCaches: excludeCaches, skipIfUnchanged: skipIfUnchanged)
+        BackupOptions(
+            excludeCaches: excludeCaches,
+            oneFileSystem: oneFileSystem,
+            skipIfUnchanged: skipIfUnchanged
+        )
     }
 
     func addExcludePattern() {

--- a/Keelhaven/Support/PlanOptionsDraft.swift
+++ b/Keelhaven/Support/PlanOptionsDraft.swift
@@ -16,8 +16,8 @@ final class PlanOptionsDraft {
     var excludePatterns: [String]
     var checkCadence: CheckCadence
     var retention: RetentionPolicy
-    /// The two boolean `restic backup` switches (issue #46). Off by default,
-    /// like every other advanced setting here.
+    /// The boolean `restic backup` switches (issues #46, #50). Off by
+    /// default, like every other advanced setting here.
     var excludeCaches = false
     var oneFileSystem = false
     var skipIfUnchanged = false

--- a/Keelhaven/Support/PlanOptionsUI.swift
+++ b/Keelhaven/Support/PlanOptionsUI.swift
@@ -160,6 +160,16 @@ struct ExcludePatternsSection: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                // Same kind of rule as the one above — what not to read —
+                // and the label says what actually happens rather than
+                // naming a file system boundary (issue #50).
+                Toggle("Don't back up other disks mounted inside these folders", isOn: $options.oneFileSystem)
+                    .toggleStyle(.checkbox)
+                Text("Stops at the disk each folder lives on. Without this, an external drive or a network share mounted inside one of them is backed up too.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.top, 6)
         }

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
@@ -15,6 +15,13 @@ import Foundation
 public struct BackupOptions: Codable, Hashable, Sendable {
     /// `--exclude-caches`: skip directories tagged with `CACHEDIR.TAG`.
     public var excludeCaches: Bool
+    /// `--one-file-system`: stop at the boundary of the disk each source
+    /// folder lives on, instead of following into anything mounted below it.
+    ///
+    /// Picking a folder is a directory choice, but what gets read is whatever
+    /// is *mounted* underneath — on a Mac routinely an external drive or a
+    /// network share sitting inside the source tree (issue #50).
+    public var oneFileSystem: Bool
     /// `--skip-if-unchanged`: write no snapshot when the content is identical
     /// to the parent snapshot.
     ///
@@ -26,8 +33,13 @@ public struct BackupOptions: Codable, Hashable, Sendable {
     /// Both switches off — restic's own behaviour.
     public static let off = BackupOptions()
 
-    public init(excludeCaches: Bool = false, skipIfUnchanged: Bool = false) {
+    public init(
+        excludeCaches: Bool = false,
+        oneFileSystem: Bool = false,
+        skipIfUnchanged: Bool = false
+    ) {
         self.excludeCaches = excludeCaches
+        self.oneFileSystem = oneFileSystem
         self.skipIfUnchanged = skipIfUnchanged
     }
 
@@ -40,13 +52,14 @@ public struct BackupOptions: Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             excludeCaches: try container.decodeIfPresent(Bool.self, forKey: .excludeCaches) ?? false,
+            oneFileSystem: try container.decodeIfPresent(Bool.self, forKey: .oneFileSystem) ?? false,
             skipIfUnchanged: try container.decodeIfPresent(Bool.self, forKey: .skipIfUnchanged) ?? false
         )
     }
 
     /// True when restic is left entirely to its own behaviour.
     public var isDefault: Bool {
-        !excludeCaches && !skipIfUnchanged
+        !excludeCaches && !oneFileSystem && !skipIfUnchanged
     }
 
     /// The flags for this configuration, empty when nothing is set.
@@ -57,6 +70,11 @@ public struct BackupOptions: Codable, Hashable, Sendable {
         var args: [String] = []
         if excludeCaches {
             args.append("--exclude-caches")
+        }
+        // Next to `--exclude-caches` because it is the same kind of thing —
+        // a rule about what not to read — and the UI groups them together.
+        if oneFileSystem {
+            args.append("--one-file-system")
         }
         if skipIfUnchanged {
             args.append("--skip-if-unchanged")

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
@@ -30,7 +30,7 @@ public struct BackupOptions: Codable, Hashable, Sendable {
     /// tell someone a backup was stored when none was.
     public var skipIfUnchanged: Bool
 
-    /// Both switches off — restic's own behaviour.
+    /// Every switch off — restic's own behaviour.
     public static let off = BackupOptions()
 
     public init(

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -213,7 +213,18 @@ final class ModelRoundTripTests: XCTestCase {
         let partial = try XCTUnwrap(#"{"excludeCaches":true}"#.data(using: .utf8))
         let decodedPartial = try decoder.decode(BackupOptions.self, from: partial)
         XCTAssertTrue(decodedPartial.excludeCaches)
+        XCTAssertFalse(decodedPartial.oneFileSystem)
         XCTAssertFalse(decodedPartial.skipIfUnchanged)
+
+        // The shape a 0.8.0 plans.json has: the two switches that shipped
+        // first are present, the third is not (issue #50).
+        let previousRelease = try XCTUnwrap(
+            #"{"excludeCaches":true,"skipIfUnchanged":true}"#.data(using: .utf8)
+        )
+        let decodedPrevious = try decoder.decode(BackupOptions.self, from: previousRelease)
+        XCTAssertTrue(decodedPrevious.excludeCaches)
+        XCTAssertTrue(decodedPrevious.skipIfUnchanged)
+        XCTAssertFalse(decodedPrevious.oneFileSystem)
 
         let empty = try XCTUnwrap("{}".data(using: .utf8))
         XCTAssertEqual(try decoder.decode(BackupOptions.self, from: empty), .off)
@@ -225,11 +236,12 @@ final class ModelRoundTripTests: XCTestCase {
             sourcePaths: ["/Users/me/Documents"],
             destination: .local(path: "/Volumes/Backup/repo"),
             schedule: .hourly,
-            backupOptions: BackupOptions(excludeCaches: true, skipIfUnchanged: true),
+            backupOptions: BackupOptions(excludeCaches: true, oneFileSystem: true, skipIfUnchanged: true),
             createdAt: date
         )
         let decoded = try roundTrip(plan)
         XCTAssertTrue(decoded.backupOptions.excludeCaches)
+        XCTAssertTrue(decoded.backupOptions.oneFileSystem)
         XCTAssertTrue(decoded.backupOptions.skipIfUnchanged)
         XCTAssertFalse(decoded.backupOptions.isDefault)
     }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
@@ -97,8 +97,10 @@ final class ResticCommandTests: XCTestCase {
         XCTAssertEqual(BackupOptions.off.arguments, [])
         XCTAssertTrue(BackupOptions.off.isDefault)
         XCTAssertEqual(BackupOptions(excludeCaches: true).arguments, ["--exclude-caches"])
+        XCTAssertEqual(BackupOptions(oneFileSystem: true).arguments, ["--one-file-system"])
         XCTAssertEqual(BackupOptions(skipIfUnchanged: true).arguments, ["--skip-if-unchanged"])
         XCTAssertFalse(BackupOptions(excludeCaches: true).isDefault)
+        XCTAssertFalse(BackupOptions(oneFileSystem: true).isDefault)
         XCTAssertFalse(BackupOptions(skipIfUnchanged: true).isDefault)
     }
 
@@ -110,12 +112,13 @@ final class ResticCommandTests: XCTestCase {
             excludes: ["*.log"],
             tag: "keelhaven",
             performance: PerformanceOptions(packSizeMiB: 64),
-            options: BackupOptions(excludeCaches: true, skipIfUnchanged: true)
+            options: BackupOptions(excludeCaches: true, oneFileSystem: true, skipIfUnchanged: true)
         )
         XCTAssertEqual(command.arguments, [
             "backup", "--json",
             "--pack-size", "64",
             "--exclude-caches",
+            "--one-file-system",
             "--skip-if-unchanged",
             "--exclude", "*.log",
             "--tag", "keelhaven",
@@ -129,6 +132,7 @@ final class ResticCommandTests: XCTestCase {
     func testForgetCarriesNoBackupOptions() {
         let command = ResticCommand.forget(retention: .month, performance: .off)
         XCTAssertFalse(command.arguments.contains("--exclude-caches"))
+        XCTAssertFalse(command.arguments.contains("--one-file-system"))
         XCTAssertFalse(command.arguments.contains("--skip-if-unchanged"))
     }
 

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -506,4 +506,153 @@ final class ResticRunnerIntegrationTests: XCTestCase {
         )
         XCTAssertEqual(snapshots.count, 1)
     }
+
+    /// `--one-file-system` against the real binary, with a real second
+    /// volume mounted inside the source — the only arrangement where the
+    /// flag does anything at all.
+    ///
+    /// A disk image is created and attached under the source folder, so the
+    /// backup has a genuine filesystem boundary to stop at. Asserted by
+    /// listing the snapshot rather than by trusting the summary counts: a
+    /// restic that silently ignored the flag would report plausible numbers.
+    /// Skips, rather than fails, when `hdiutil` cannot create or attach the
+    /// image — the same self-skipping rule the rest of this suite follows.
+    func testOneFileSystemStopsAtAMountedVolume() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let repoURL = workDirectory.appendingPathComponent("repo", isDirectory: true)
+        let sourceURL = workDirectory.appendingPathComponent("src", isDirectory: true)
+        let mountURL = sourceURL.appendingPathComponent("mounted", isDirectory: true)
+        try FileManager.default.createDirectory(at: mountURL, withIntermediateDirectories: true)
+        try Data("on the main disk\n".utf8).write(to: sourceURL.appendingPathComponent("keep.txt"))
+
+        let imageURL = workDirectory.appendingPathComponent("volume.dmg")
+        guard Self.run("/usr/bin/hdiutil", [
+            "create", "-size", "10m", "-fs", "HFS+", "-volname", "KeelhavenTest",
+            "-quiet", imageURL.path,
+        ]) else {
+            throw XCTSkip("hdiutil could not create a disk image here")
+        }
+        guard Self.run("/usr/bin/hdiutil", [
+            "attach", imageURL.path, "-mountpoint", mountURL.path, "-nobrowse", "-quiet",
+        ]) else {
+            throw XCTSkip("hdiutil could not attach a disk image here")
+        }
+        defer { _ = Self.run("/usr/bin/hdiutil", ["detach", mountURL.path, "-quiet"]) }
+
+        try Data("on the other volume\n".utf8)
+            .write(to: mountURL.appendingPathComponent("other.txt"))
+
+        let destination = Destination.local(path: repoURL.path)
+        let credentials = RepoCredentials(repositoryPassword: "integration-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+
+        func backup(oneFileSystem: Bool) async throws -> BackupSummary? {
+            var summary: BackupSummary?
+            let stream = runner.backupStream(
+                .backup(
+                    sources: [sourceURL.path],
+                    excludes: [],
+                    tag: "keelhaven-test",
+                    performance: .off,
+                    options: BackupOptions(oneFileSystem: oneFileSystem)
+                ),
+                destination: destination,
+                credentials: credentials
+            )
+            for try await event in stream {
+                if case .summary(let value) = event { summary = value }
+            }
+            return summary
+        }
+
+        // Without the flag, the mounted volume is followed into.
+        let withoutSummary = try await backup(oneFileSystem: false)
+        let withoutID = try XCTUnwrap(try XCTUnwrap(withoutSummary).snapshotID)
+        let withoutFiles = try await Self.restoredFileNames(
+            runner: runner,
+            snapshotID: withoutID,
+            destination: destination,
+            credentials: credentials,
+            sourcePath: sourceURL.path,
+            target: workDirectory.appendingPathComponent("restored-without", isDirectory: true)
+        )
+        XCTAssertTrue(withoutFiles.contains("keep.txt"))
+        XCTAssertTrue(
+            withoutFiles.contains("mounted/other.txt"),
+            "Without the flag restic should cross into the mounted volume"
+        )
+
+        // With it, the boundary is respected.
+        let withSummary = try await backup(oneFileSystem: true)
+        let withID = try XCTUnwrap(try XCTUnwrap(withSummary).snapshotID)
+        let withFiles = try await Self.restoredFileNames(
+            runner: runner,
+            snapshotID: withID,
+            destination: destination,
+            credentials: credentials,
+            sourcePath: sourceURL.path,
+            target: workDirectory.appendingPathComponent("restored-with", isDirectory: true)
+        )
+        XCTAssertTrue(withFiles.contains("keep.txt"), "The folder's own files must still be backed up")
+        XCTAssertFalse(
+            withFiles.contains("mounted/other.txt"),
+            "A file on a volume mounted inside the source should have been skipped"
+        )
+    }
+
+    /// Restores a snapshot and returns the paths inside it, relative to the
+    /// backed-up folder — the only way to see what restic actually stored.
+    private static func restoredFileNames(
+        runner: ResticRunner,
+        snapshotID: String,
+        destination: Destination,
+        credentials: RepoCredentials,
+        sourcePath: String,
+        target: URL
+    ) async throws -> Set<String> {
+        try await runner.runIgnoringOutput(
+            .restore(snapshotID: snapshotID, target: target.path),
+            destination: destination,
+            credentials: credentials
+        )
+        let root = target.appendingPathComponent(sourcePath)
+        guard let walker = FileManager.default.enumerator(atPath: root.path) else { return [] }
+        var found: Set<String> = []
+        for case let path as String in walker {
+            var isDirectory: ObjCBool = false
+            let full = root.appendingPathComponent(path).path
+            if FileManager.default.fileExists(atPath: full, isDirectory: &isDirectory),
+               !isDirectory.boolValue {
+                found.insert(path)
+            }
+        }
+        return found
+    }
+
+    /// Runs a command and reports whether it succeeded, so the caller can
+    /// skip instead of failing when the environment will not cooperate.
+    private static func run(_ launchPath: String, _ arguments: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
 }
+


### PR DESCRIPTION
Fixes #50

Branched from `main` at 40bef8c.

## Why

Third and last of the switches the user in #45 listed, and the one that prevents the largest surprise. Picking a folder is a directory choice, but what gets *read* is whatever is mounted underneath it — on a Mac routinely an external drive or a network share sitting inside the source tree. The failure is always the same shape: a backup that was supposed to be "my Documents" quietly starts pulling in 2 TB.

## What changed

A third `Bool` on the `BackupOptions` struct #46 established — which is exactly what that issue predicted this would be once it landed.

The per-field decode fallback added there earns itself now: a `plans.json` written by the previous release carries `excludeCaches` and `skipIfUnchanged` but not this one, and loads with no migration. There is a test pinning that exact shape.

The checkbox sits **with the exclude patterns**, not under Advanced: it is the same kind of rule — what not to read — and it belongs next to *Skip cache folders*. The label says what happens (*"Don't back up other disks mounted inside these folders"*) rather than naming a filesystem boundary. Off by default, like every other advanced switch.

## Verification

**Against real restic, with a real second volume.** A 10 MB disk image is created with `hdiutil` and attached *inside* the source folder, so the backup has a genuine filesystem boundary to stop at:

| | snapshot contains |
|---|---|
| without the flag | `keep.txt` **and** `mounted/other.txt` |
| with the flag | `keep.txt` only |

Asserted by restoring the snapshot and listing what came back, not by trusting summary counts — those look plausible either way. The test skips rather than fails when `hdiutil` cannot create or attach an image, following this suite's existing self-skipping rule, and detaches in a `defer`. Run three times: passes each time in ~6.8s, with no mount left behind.

Also:

- **150 tests, 0 failures.** Line coverage stays 100% on KeelhavenCore; `BackupOptions.swift` is 100%.
- Argument order pinned: `--exclude-caches`, `--one-file-system`, `--skip-if-unchanged`, and a test asserting none of the three can reach `forget`.
- Localization cross-checked against Xcode's extracted `.stringsdata`; both new strings ship with Simplified Chinese.
- Screenshotted in Edit Plan in English and Simplified Chinese, with a plan seeded as `{"excludeCaches": true, "oneFileSystem": true, "skipIfUnchanged": true}` so the shots also prove the decode path. Both exclusion checkboxes render together and read as checked.

## Note

This closes out the list from that user's message: `--pack-size` already shipped in 0.7.0, `--exclude-caches` and `--skip-if-unchanged` in #54, and `--one-file-system` here. What remains from it is `--no-scan` (#51, needs the progress-bar decision first), `--exclude-file` (leaning no, discussed on #45), `--keep-last` (#52) and `-o rclone.program` (#53, not scheduled).