### PR TITLE
Add `--no-scan` as a named backup option, with honest progress

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -5,11 +5,14 @@ import KeelhavenCore
 
 enum PlanRunState: Equatable {
     case idle
-    case running(progress: Double)
+    /// `progress` is nil when restic cannot say how far along it is —
+    /// `--no-scan` omits `total_bytes`, so there is nothing to divide by
+    /// (issue #51). `bytesDone` is what the row shows instead.
+    case running(progress: Double?, bytesDone: Int64?)
     case checking
     /// A dry run: restic is walking the sources to report what a backup
     /// would store, writing nothing (issue #43).
-    case previewing(progress: Double)
+    case previewing(progress: Double?)
     case pruning
     case unlocking
     case succeeded(Date)
@@ -237,6 +240,18 @@ final class AppState {
         return nil
     }
 
+    /// How far along restic says it is, or nil when it cannot say.
+    ///
+    /// Keyed on `total_bytes` rather than on the plan's `noScan` setting: that
+    /// field's absence is what actually makes a percentage uncomputable, so
+    /// the row stays honest even if restic changes when it omits it. A zero
+    /// total is treated the same way — an empty source has no percentage to
+    /// report either, and dividing by it would be worse.
+    private static func progress(from status: BackupStatusMessage) -> Double? {
+        guard let totalBytes = status.totalBytes, totalBytes > 0 else { return nil }
+        return status.percentDone
+    }
+
     // MARK: - Running backups
 
     /// True while any plan has a restic process going — a backup, a
@@ -261,7 +276,7 @@ final class AppState {
             return
         }
 
-        runStates[plan.id] = .running(progress: 0)
+        runStates[plan.id] = .running(progress: nil, bytesDone: nil)
         Task {
             await self.performBackup(plan, binaryURL: binaryURL)
         }
@@ -288,7 +303,10 @@ final class AppState {
             for try await event in stream {
                 switch event {
                 case .status(let status):
-                    runStates[plan.id] = .running(progress: status.percentDone)
+                    runStates[plan.id] = .running(
+                        progress: Self.progress(from: status),
+                        bytesDone: status.bytesDone
+                    )
                 case .summary(let value):
                     summary = value
                 }
@@ -440,7 +458,7 @@ final class AppState {
         }
 
         let stateBefore = runStates[plan.id] ?? .idle
-        runStates[plan.id] = .previewing(progress: 0)
+        runStates[plan.id] = .previewing(progress: nil)
         defer { runStates[plan.id] = stateBefore }
 
         do {
@@ -461,7 +479,7 @@ final class AppState {
             for try await event in stream {
                 switch event {
                 case .status(let status):
-                    runStates[plan.id] = .previewing(progress: status.percentDone)
+                    runStates[plan.id] = .previewing(progress: Self.progress(from: status))
                 case .summary(let value):
                     summary = value
                 }

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -1,6 +1,16 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "%@ backed up so far": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已备份 %@"
+          }
+        }
+      }
+    },
     "%@ finished successfully.": {
       "localizations": {
         "zh-Hans": {
@@ -484,6 +494,16 @@
         }
       }
     },
+    "Backup running, %@ so far": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份进行中，已备份 %@"
+          }
+        }
+      }
+    },
     "Backup verification failed": {
       "localizations": {
         "zh-Hans": {
@@ -890,6 +910,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "不要备份挂载在这些文件夹里的其它磁盘"
+          }
+        }
+      }
+    },
+    "Don't measure the backup first": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不要先测量备份大小"
           }
         }
       }
@@ -2579,6 +2609,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "restic 许可证（BSD 2-Clause）"
+          }
+        }
+      }
+    },
+    "restic normally walks your folders a second time to work out how big the backup will be. Skipping that can help on a slow disk or a network share — but then the progress can only show how much has been copied, not how far along it is.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "restic 通常会再遍历一遍你的文件夹，算出这次备份有多大。跳过这一步在慢速磁盘或网络共享上会更快——但之后进度只能显示已经复制了多少，无法显示进行到了哪一步。"
           }
         }
       }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -338,6 +338,12 @@ struct PlanStatusRow: View {
         }
     }
 
+    /// Same formatter the completion notification uses, so "48 MB" in the
+    /// row and "48 MB" in the notification never disagree.
+    private static func formatted(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
     /// Secondary, not orange or red: nothing is wrong. The plan checked, the
     /// folders were identical to the last snapshot, and nothing needed
     /// storing — which is the whole point of the option.
@@ -388,11 +394,33 @@ struct PlanStatusRow: View {
     @ViewBuilder
     private var statusLine: some View {
         switch runState {
-        case .running(let progress):
-            ProgressView(value: progress)
-                .controlSize(.small)
+        case .running(let progress, let bytesDone):
+            if let progress {
+                ProgressView(value: progress)
+                    .controlSize(.small)
+                    .padding(.top, 2)
+                    .accessibilityLabel(String(localized: "Backup \(Int(progress * 100)) percent done"))
+            } else {
+                // No percentage to show — `--no-scan` means restic never
+                // measured the sources (issue #51). The bar spins and the
+                // amount copied stands in for it, which is the honest answer
+                // rather than a bar frozen at zero.
+                VStack(alignment: .leading, spacing: 4) {
+                    if let bytesDone {
+                        Text("\(Self.formatted(bytesDone)) backed up so far")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView()
+                        .controlSize(.small)
+                }
                 .padding(.top, 2)
-                .accessibilityLabel(String(localized: "Backup \(Int(progress * 100)) percent done"))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(
+                    bytesDone.map { String(localized: "Backup running, \(Self.formatted($0)) so far") }
+                        ?? String(localized: "Backup running")
+                )
+            }
         case .previewing(let progress):
             // Deliberately not a bare progress bar like `.running`: the two
             // would be indistinguishable, and someone glancing at the panel
@@ -401,11 +429,19 @@ struct PlanStatusRow: View {
                 Text("Previewing what would be backed up…")
                     .font(.callout)
                     .foregroundStyle(.secondary)
-                ProgressView(value: progress)
-                    .controlSize(.small)
+                if let progress {
+                    ProgressView(value: progress)
+                        .controlSize(.small)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
             }
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel(String(localized: "Backup preview \(Int(progress * 100)) percent done"))
+            .accessibilityLabel(
+                progress.map { String(localized: "Backup preview \(Int($0 * 100)) percent done") }
+                    ?? String(localized: "Backup preview running")
+            )
         case .checking:
             HStack(spacing: 6) {
                 ProgressView()

--- a/Keelhaven/Support/PlanOptionsDraft.swift
+++ b/Keelhaven/Support/PlanOptionsDraft.swift
@@ -20,6 +20,7 @@ final class PlanOptionsDraft {
     /// default, like every other advanced setting here.
     var excludeCaches = false
     var oneFileSystem = false
+    var noScan = false
     var skipIfUnchanged = false
     /// Scratch field for the exclude-pattern TextField.
     var newExcludePattern = ""
@@ -48,6 +49,7 @@ final class PlanOptionsDraft {
         retention = plan.retention
         excludeCaches = plan.backupOptions.excludeCaches
         oneFileSystem = plan.backupOptions.oneFileSystem
+        noScan = plan.backupOptions.noScan
         skipIfUnchanged = plan.backupOptions.skipIfUnchanged
         newExcludePattern = ""
         uploadLimitText = Self.text(plan.performance.uploadLimitKiBPerSecond)
@@ -73,6 +75,7 @@ final class PlanOptionsDraft {
         BackupOptions(
             excludeCaches: excludeCaches,
             oneFileSystem: oneFileSystem,
+            noScan: noScan,
             skipIfUnchanged: skipIfUnchanged
         )
     }

--- a/Keelhaven/Support/PlanOptionsUI.swift
+++ b/Keelhaven/Support/PlanOptionsUI.swift
@@ -195,6 +195,17 @@ struct AdvancedPerformanceSection: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                // The only setting in the app that trades away part of the
+                // interface, so the explanation says so outright — a progress
+                // bar that stops showing a percentage reads as a bug when
+                // nobody warned you (issue #51).
+                Toggle("Don't measure the backup first", isOn: $options.noScan)
+                    .toggleStyle(.checkbox)
+                Text("restic normally walks your folders a second time to work out how big the backup will be. Skipping that can help on a slow disk or a network share — but then the progress can only show how much has been copied, not how far along it is.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Divider()
 
                 Text("Leave these empty unless a backup is too slow or takes too much of your connection. Empty means restic's own default.")

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupOptions.swift
@@ -8,10 +8,12 @@ import Foundation
 /// `Int?`. These change *what gets backed up* and *whether a snapshot is
 /// written* — different question, different type (issue #46).
 ///
-/// Every field here must be a flag that leaves restic's `--json` event stream
-/// intact, since the progress UI and every run record are parsed from it.
-/// `--no-scan` is the counter-example and is deliberately not here: it holds
-/// `percent_done` at 0 for the whole run (issue #51).
+/// Every field here must be a flag the `--json` event stream survives, since
+/// the progress UI and every run record are parsed from it. The rule is not
+/// "changes nothing" but "breaks nothing the app reads": `--no-scan` drops
+/// `total_bytes` and pins `percent_done` at 0, which the row already has to
+/// tolerate and now handles explicitly (issue #51), while `--quiet` and
+/// `--verbose` change which message types arrive at all and stay ruled out.
 public struct BackupOptions: Codable, Hashable, Sendable {
     /// `--exclude-caches`: skip directories tagged with `CACHEDIR.TAG`.
     public var excludeCaches: Bool
@@ -22,6 +24,18 @@ public struct BackupOptions: Codable, Hashable, Sendable {
     /// is *mounted* underneath — on a Mac routinely an external drive or a
     /// network share sitting inside the source tree (issue #50).
     public var oneFileSystem: Bool
+    /// `--no-scan`: skip the concurrent scan that measures the sources up
+    /// front, purely so restic can report a percentage.
+    ///
+    /// The scan is a second walk of the tree running alongside the backup, so
+    /// it costs contention rather than a phase — free on an SSD, seek
+    /// contention on a spinning disk, a round trip per file on a network
+    /// share, which is the case restic added the flag for.
+    ///
+    /// Callers must handle the consequence: restic then omits `total_bytes`
+    /// from every status line and holds `percent_done` at 0, so a percentage
+    /// cannot be computed and the row falls back to how much has been copied.
+    public var noScan: Bool
     /// `--skip-if-unchanged`: write no snapshot when the content is identical
     /// to the parent snapshot.
     ///
@@ -36,10 +50,12 @@ public struct BackupOptions: Codable, Hashable, Sendable {
     public init(
         excludeCaches: Bool = false,
         oneFileSystem: Bool = false,
+        noScan: Bool = false,
         skipIfUnchanged: Bool = false
     ) {
         self.excludeCaches = excludeCaches
         self.oneFileSystem = oneFileSystem
+        self.noScan = noScan
         self.skipIfUnchanged = skipIfUnchanged
     }
 
@@ -53,13 +69,14 @@ public struct BackupOptions: Codable, Hashable, Sendable {
         self.init(
             excludeCaches: try container.decodeIfPresent(Bool.self, forKey: .excludeCaches) ?? false,
             oneFileSystem: try container.decodeIfPresent(Bool.self, forKey: .oneFileSystem) ?? false,
+            noScan: try container.decodeIfPresent(Bool.self, forKey: .noScan) ?? false,
             skipIfUnchanged: try container.decodeIfPresent(Bool.self, forKey: .skipIfUnchanged) ?? false
         )
     }
 
     /// True when restic is left entirely to its own behaviour.
     public var isDefault: Bool {
-        !excludeCaches && !oneFileSystem && !skipIfUnchanged
+        !excludeCaches && !oneFileSystem && !noScan && !skipIfUnchanged
     }
 
     /// The flags for this configuration, empty when nothing is set.
@@ -75,6 +92,9 @@ public struct BackupOptions: Codable, Hashable, Sendable {
         // a rule about what not to read — and the UI groups them together.
         if oneFileSystem {
             args.append("--one-file-system")
+        }
+        if noScan {
+            args.append("--no-scan")
         }
         if skipIfUnchanged {
             args.append("--skip-if-unchanged")

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/Fixtures/backup-no-scan.jsonl
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/Fixtures/backup-no-scan.jsonl
@@ -1,0 +1,17 @@
+{"message_type":"status","percent_done":0,"files_done":194,"bytes_done":58500000,"current_files":["/ns/src/f0195.bin","/ns/src/f0196.bin"]}
+{"message_type":"status","percent_done":0,"files_done":293,"bytes_done":90300000,"current_files":["/ns/src/f0299.bin","/ns/src/f0301.bin"]}
+{"message_type":"status","percent_done":0,"files_done":491,"bytes_done":147900000,"current_files":["/ns/src/f0493.bin","/ns/src/f0494.bin"]}
+{"message_type":"status","percent_done":0,"files_done":637,"bytes_done":193500000,"current_files":["/ns/src/f0645.bin","/ns/src/f0646.bin"]}
+{"message_type":"status","percent_done":0,"files_done":815,"bytes_done":244800000,"current_files":["/ns/src/f0816.bin","/ns/src/f0817.bin"]}
+{"message_type":"status","percent_done":0,"files_done":969,"bytes_done":292200000,"current_files":["/ns/src/f0970.bin","/ns/src/f0973.bin"]}
+{"message_type":"status","percent_done":0,"files_done":1149,"bytes_done":345900000,"current_files":["/ns/src/f1153.bin"]}
+{"message_type":"status","percent_done":0,"files_done":1301,"bytes_done":391800000,"current_files":["/ns/src/f1303.bin","/ns/src/f1305.bin"]}
+{"message_type":"status","percent_done":0,"files_done":1466,"bytes_done":442200000,"current_files":["/ns/src/f1474.bin","/ns/src/f1475.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":1601,"bytes_done":481800000,"current_files":["/ns/src/f1606.bin","/ns/src/f1607.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":1780,"bytes_done":534900000,"current_files":["/ns/src/f1783.bin","/ns/src/f1784.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":1934,"bytes_done":582600000,"current_files":["/ns/src/f1942.bin","/ns/src/f1943.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":2086,"bytes_done":628200000,"current_files":["/ns/src/f2094.bin","/ns/src/f2095.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":2262,"bytes_done":679500000,"current_files":["/ns/src/f2265.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":2446,"bytes_done":735000000,"current_files":["/ns/src/f2450.bin","/ns/src/f2451.bin"]}
+{"message_type":"status","seconds_elapsed":1,"percent_done":0,"files_done":2500,"bytes_done":750000000}
+{"message_type":"summary","files_new":2500,"files_changed":0,"files_unmodified":0,"dirs_new":2,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":2500,"tree_blobs":3,"data_added":751137658,"data_added_packed":750369607,"total_files_processed":2500,"total_bytes_processed":750000000,"total_duration":2.2957895,"backup_start":"2026-09-09T08:19:27.06902+03:00","backup_end":"2026-09-09T08:19:29.364792+03:00","snapshot_id":"25a086702a091207b2ba95d075a59018c204923884b710832464ca456c404c64"}

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -214,17 +214,19 @@ final class ModelRoundTripTests: XCTestCase {
         let decodedPartial = try decoder.decode(BackupOptions.self, from: partial)
         XCTAssertTrue(decodedPartial.excludeCaches)
         XCTAssertFalse(decodedPartial.oneFileSystem)
+        XCTAssertFalse(decodedPartial.noScan)
         XCTAssertFalse(decodedPartial.skipIfUnchanged)
 
         // The shape a 0.8.0 plans.json has: the two switches that shipped
         // first are present, the third is not (issue #50).
         let previousRelease = try XCTUnwrap(
-            #"{"excludeCaches":true,"skipIfUnchanged":true}"#.data(using: .utf8)
+            #"{"excludeCaches":true,"oneFileSystem":true,"skipIfUnchanged":true}"#.data(using: .utf8)
         )
         let decodedPrevious = try decoder.decode(BackupOptions.self, from: previousRelease)
         XCTAssertTrue(decodedPrevious.excludeCaches)
+        XCTAssertTrue(decodedPrevious.oneFileSystem)
         XCTAssertTrue(decodedPrevious.skipIfUnchanged)
-        XCTAssertFalse(decodedPrevious.oneFileSystem)
+        XCTAssertFalse(decodedPrevious.noScan, "The switch that shipped last must default off, not carry over")
 
         let empty = try XCTUnwrap("{}".data(using: .utf8))
         XCTAssertEqual(try decoder.decode(BackupOptions.self, from: empty), .off)
@@ -236,12 +238,15 @@ final class ModelRoundTripTests: XCTestCase {
             sourcePaths: ["/Users/me/Documents"],
             destination: .local(path: "/Volumes/Backup/repo"),
             schedule: .hourly,
-            backupOptions: BackupOptions(excludeCaches: true, oneFileSystem: true, skipIfUnchanged: true),
+            backupOptions: BackupOptions(
+                excludeCaches: true, oneFileSystem: true, noScan: true, skipIfUnchanged: true
+            ),
             createdAt: date
         )
         let decoded = try roundTrip(plan)
         XCTAssertTrue(decoded.backupOptions.excludeCaches)
         XCTAssertTrue(decoded.backupOptions.oneFileSystem)
+        XCTAssertTrue(decoded.backupOptions.noScan)
         XCTAssertTrue(decoded.backupOptions.skipIfUnchanged)
         XCTAssertFalse(decoded.backupOptions.isDefault)
     }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticCommandTests.swift
@@ -122,6 +122,17 @@ final class ResticCommandTests: XCTestCase {
         XCTAssertEqual(withoutDryRun, backup.arguments)
     }
 
+    /// A preview of a `--no-scan` plan must itself be `--no-scan`: the whole
+    /// point of `previewBackup` is that it is the command that will actually
+    /// run (issue #43), and dropping the flag would preview a different one.
+    func testPreviewInheritsNoScanFromThePlan() {
+        let command = ResticCommand.previewBackup(
+            sources: ["/tmp/data"], excludes: [], tag: nil,
+            performance: .off, options: BackupOptions(noScan: true)
+        )
+        XCTAssertEqual(command.arguments, ["backup", "--json", "--dry-run", "--no-scan", "/tmp/data"])
+    }
+
     func testPreviewBackupArgumentOrder() {
         let command = ResticCommand.previewBackup(
             sources: ["/tmp/data"], excludes: [], tag: nil,
@@ -137,9 +148,11 @@ final class ResticCommandTests: XCTestCase {
         XCTAssertTrue(BackupOptions.off.isDefault)
         XCTAssertEqual(BackupOptions(excludeCaches: true).arguments, ["--exclude-caches"])
         XCTAssertEqual(BackupOptions(oneFileSystem: true).arguments, ["--one-file-system"])
+        XCTAssertEqual(BackupOptions(noScan: true).arguments, ["--no-scan"])
         XCTAssertEqual(BackupOptions(skipIfUnchanged: true).arguments, ["--skip-if-unchanged"])
         XCTAssertFalse(BackupOptions(excludeCaches: true).isDefault)
         XCTAssertFalse(BackupOptions(oneFileSystem: true).isDefault)
+        XCTAssertFalse(BackupOptions(noScan: true).isDefault)
         XCTAssertFalse(BackupOptions(skipIfUnchanged: true).isDefault)
     }
 
@@ -151,13 +164,16 @@ final class ResticCommandTests: XCTestCase {
             excludes: ["*.log"],
             tag: "keelhaven",
             performance: PerformanceOptions(packSizeMiB: 64),
-            options: BackupOptions(excludeCaches: true, oneFileSystem: true, skipIfUnchanged: true)
+            options: BackupOptions(
+                excludeCaches: true, oneFileSystem: true, noScan: true, skipIfUnchanged: true
+            )
         )
         XCTAssertEqual(command.arguments, [
             "backup", "--json",
             "--pack-size", "64",
             "--exclude-caches",
             "--one-file-system",
+            "--no-scan",
             "--skip-if-unchanged",
             "--exclude", "*.log",
             "--tag", "keelhaven",
@@ -172,6 +188,7 @@ final class ResticCommandTests: XCTestCase {
         let command = ResticCommand.forget(retention: .month, performance: .off)
         XCTAssertFalse(command.arguments.contains("--exclude-caches"))
         XCTAssertFalse(command.arguments.contains("--one-file-system"))
+        XCTAssertFalse(command.arguments.contains("--no-scan"))
         XCTAssertFalse(command.arguments.contains("--skip-if-unchanged"))
     }
 

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticMessageParsingTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticMessageParsingTests.swift
@@ -113,6 +113,58 @@ final class ResticMessageParsingTests: XCTestCase {
         XCTAssertNil(real.dryRun)
     }
 
+    /// Unmodified `restic backup --json --no-scan` output from restic 0.19.1.
+    ///
+    /// This fixture exists to pin the exact shape the progress row has to cope
+    /// with (issue #51): `percent_done` never moves off 0 and `total_bytes` is
+    /// gone, so no percentage can be computed — but `bytes_done` keeps
+    /// climbing, which is what the row shows instead.
+    func testDecodeEveryNoScanLine() throws {
+        let lines = try fixtureLines("backup-no-scan.jsonl")
+        XCTAssertEqual(lines.count, 17)
+
+        var statusCount = 0
+        var lastBytesDone: Int64 = 0
+        var summary: BackupSummary?
+        for line in lines {
+            switch try XCTUnwrap(ResticJSON.decodeProgressEvent(fromLine: line)) {
+            case .status(let status):
+                statusCount += 1
+                XCTAssertEqual(status.percentDone, 0, "--no-scan never reports progress")
+                XCTAssertNil(status.totalBytes, "--no-scan omits the total it could not measure")
+                XCTAssertNil(status.totalFiles)
+                let bytesDone = try XCTUnwrap(status.bytesDone)
+                XCTAssertGreaterThan(bytesDone, lastBytesDone, "bytes_done must keep climbing")
+                lastBytesDone = bytesDone
+            case .summary(let value):
+                summary = value
+            }
+        }
+        XCTAssertEqual(statusCount, 16)
+
+        // The summary is untouched, which is why the run record, the
+        // notification and the history are unaffected by the option.
+        let final = try XCTUnwrap(summary)
+        XCTAssertEqual(final.filesNew, 2500)
+        XCTAssertEqual(final.dataAdded, 751_137_658)
+        XCTAssertNotNil(final.snapshotID)
+        XCTAssertNil(final.dryRun)
+    }
+
+    /// The contrast that makes the fallback necessary: an ordinary backup
+    /// reports both the total and a moving percentage.
+    func testAnOrdinaryBackupReportsTheTotalNoScanOmits() throws {
+        let lines = try fixtureLines("backup-progress.jsonl")
+        var sawTotal = false
+        for line in lines {
+            if case .status(let status)? = ResticJSON.decodeProgressEvent(fromLine: line),
+               status.totalBytes != nil {
+                sawTotal = true
+            }
+        }
+        XCTAssertTrue(sawTotal, "A scanned backup must carry the total a --no-scan run lacks")
+    }
+
     func testDecodeEveryBackupProgressLine() throws {
         let lines = try fixtureLines("backup-progress.jsonl")
         XCTAssertEqual(lines.count, 10)

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -748,5 +748,76 @@ final class ResticRunnerIntegrationTests: XCTestCase {
             "A preview after a backup must still leave the snapshot count alone"
         )
     }
+
+    /// `--no-scan` against the real binary. Two things must both hold, and
+    /// they pull in opposite directions (issue #51): the progress fields the
+    /// row needs really do go missing, and the backup itself is otherwise
+    /// completely normal — the option must cost the estimate, not the data.
+    func testNoScanDropsTheEstimateButNotTheBackup() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let repoURL = workDirectory.appendingPathComponent("repo", isDirectory: true)
+        let sourceURL = workDirectory.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+        // Enough bytes that restic emits status lines at all; a handful of
+        // small files finishes before the first one is due.
+        for index in 0..<40 {
+            try Data(repeating: UInt8(index % 251), count: 2_000_000)
+                .write(to: sourceURL.appendingPathComponent("file\(index).bin"))
+        }
+
+        let destination = Destination.local(path: repoURL.path)
+        let credentials = RepoCredentials(repositoryPassword: "integration-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+
+        var statuses: [BackupStatusMessage] = []
+        var summary: BackupSummary?
+        let stream = runner.backupStream(
+            .backup(
+                sources: [sourceURL.path],
+                excludes: [],
+                tag: "keelhaven-test",
+                performance: .off,
+                options: BackupOptions(noScan: true)
+            ),
+            destination: destination,
+            credentials: credentials
+        )
+        for try await event in stream {
+            switch event {
+            case .status(let status): statuses.append(status)
+            case .summary(let value): summary = value
+            }
+        }
+
+        // The backup is real: a snapshot exists and the summary is complete.
+        let final = try XCTUnwrap(summary)
+        XCTAssertEqual(final.filesNew, 40)
+        XCTAssertNotNil(final.snapshotID)
+        XCTAssertNotNil(final.dataAdded)
+        let snapshots = try await runner.run(
+            .snapshots,
+            destination: destination,
+            credentials: credentials,
+            decoding: [ResticSnapshot].self
+        )
+        XCTAssertEqual(snapshots.count, 1)
+
+        // And the estimate is gone, which is what the row has to handle.
+        // Status lines are timing-dependent, so assert on them only if restic
+        // emitted any — the summary assertions above carry the test otherwise.
+        for status in statuses {
+            XCTAssertNil(status.totalBytes, "--no-scan must not report a total")
+            XCTAssertEqual(status.percentDone, 0, "--no-scan must not report progress")
+        }
+    }
 }
 


### PR DESCRIPTION
Fixes #51

Branched from `main` at 4867808. Shape agreed in discussion: ship the switch with the **minimal** honest progress handling, no history-based estimate.

## Why the switch could not ship alone

restic runs a **concurrent** scanner over the sources purely to compute a total so it can show a percentage. Its own changelog for the flag (v0.15.0, PR #3931) says why turning it off is worth having: *"This can slow down backups, especially of network filesystems."* Free on an SSD, seek contention on a spinning disk, a round trip per file over SMB.

Measured against real restic 0.19.1:

| | `percent_done` | `total_bytes` | `bytes_done` | `summary` |
|---|---|---|---|---|
| normal | `0.79` → `1` | `80000000` | populated | complete |
| `--no-scan` | **`0` on every line** | **absent** | populated | complete |

The progress bar is the one thing the app does during a backup, so a plain switch would have frozen it at zero for the whole run.

## What it does instead

`PlanRunState.running` now carries an **optional** progress plus the bytes copied. With no percentage to show, the row renders an indeterminate bar over *"1.09 GB backed up so far"* — the honest answer; a bar stuck at 0% reads as a stall. `.previewing` gets the same optional treatment, because a preview of a `--no-scan` plan is itself `--no-scan` by design (#43).

**Whether a percentage exists is decided by the data, not the setting.** `totalBytes == nil` is what actually makes it uncomputable, so the row stays correct even if restic changes when it omits the field. A zero total takes the same path rather than being divided by.

Blast radius stayed small: `statusLine` is the only switch that binds the payloads. `isActive`, `menuBarIcon`, `trailingControl`, `PlanHealth` and the accessibility label all match without binding.

## A contract that had to be rewritten

`BackupOptions`' doc comment claimed every flag in it must leave the `--json` stream intact, and **named `--no-scan` as the counter-example that must never be added**. The real rule is narrower, and is now written down: *break nothing the app reads*. `--no-scan` drops an optional field the row must already tolerate; `--quiet` and `--verbose` change which message types arrive at all and stay ruled out.

## Deliberately no history-based estimate

Last run's total would be least accurate exactly when it matters — a newly added folder makes it a severe underestimate, so the bar would race to 100% and stall, which is worse than no percentage. It would also mean persisting a field for a feature nobody has yet confirmed they need.

The optional progress is the seam if that changes: only `AppState` would start filling it in, and the view would not move.

## Verification

- **159 tests, 0 failures.** Line coverage stays 100% on KeelhavenCore; `BackupOptions.swift` is 100%.
- **Fixture** `backup-no-scan.jsonl` — unmodified `--no-scan --json` output, 16 status lines and a summary. The test asserts the exact contract the row depends on: `percentDone == 0` and `totalBytes == nil` on every status line, `bytes_done` strictly climbing, and a complete summary. A companion test asserts an ordinary backup *does* carry the total, so the fallback can't silently become the only path.
- **Integration, real restic** — a `noScan: true` backup creates its snapshot normally with a complete summary (`filesNew == 40`), while every status line lacks the total. The option must cost the estimate, not the data.
- **Runtime, isolated `HOME`, real repository** — plan created *through the wizard* so the app owns its Keychain entry, then backed up. Screenshot shows the row mid-run: blue dot, indeterminate spinner, *"1.09 GB backed up so far"*. Afterwards `lastRun` recorded `filesNew: 20000`, `dataAdded: 428243964` — the summary path untouched, which is the invariant that matters.
- Localization cross-checked against Xcode's extracted `.stringsdata`; all four new strings ship with Simplified Chinese.

## Follow-up (not this PR)

Reply on #51 with what shipped, and ask the reporter the question that would justify the history estimate later: *is a backup actually slow for you, and is the source a network share or a spinning disk?*