### PR TITLE
Add "keep the last N backups" as a fourth retention choice

### DIFF
--- a/Keelhaven/EditPlan/EditPlanWindowView.swift
+++ b/Keelhaven/EditPlan/EditPlanWindowView.swift
@@ -63,7 +63,7 @@ struct EditPlanWindowView: View {
 
                     VerificationSection(cadence: $model.options.checkCadence)
 
-                    RetentionSection(retention: $model.options.retention)
+                    RetentionSection(options: model.options)
 
                     destinationRow(for: plan)
 
@@ -93,7 +93,7 @@ struct EditPlanWindowView: View {
                         excludePatterns: model.options.excludePatterns,
                         schedule: model.builtSchedule(),
                         checkCadence: model.options.checkCadence,
-                        retention: model.options.retention,
+                        retention: model.options.builtRetention(),
                         performance: model.options.builtPerformance(),
                         backupOptions: model.options.builtBackupOptions()
                     )

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -134,6 +134,9 @@
         }
       }
     },
+    "10": {
+      "shouldTranslate": false
+    },
     "1–32": {
       "localizations": {
         "zh-Hans": {
@@ -854,6 +857,16 @@
         }
       }
     },
+    "Deletes everything older than that, however recent it is — a burst of backups in one day can push out the whole of last month. The space is reclaimed after a backup, at most once a week.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超出份数的一律删除，无论它有多新——某一天集中备份多次，就可能把上个月的记录整批挤掉。空间在备份完成后回收，每周最多清一次。"
+          }
+        }
+      }
+    },
     "Desktop": {
       "localizations": {
         "zh-Hans": {
@@ -1227,12 +1240,32 @@
         }
       }
     },
+    "Keep a set number of backups": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留固定份数的备份"
+          }
+        }
+      }
+    },
     "Keep everything": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "保留全部"
+          }
+        }
+      }
+    },
+    "Keep the last": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留最近"
           }
         }
       }
@@ -2563,6 +2596,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "请现在就把密码抄下来或存进密码管理器——没有它就无法恢复备份。"
+          }
+        }
+      }
+    },
+    "backups": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "份备份"
           }
         }
       }

--- a/Keelhaven/Support/PlanOptionsDraft.swift
+++ b/Keelhaven/Support/PlanOptionsDraft.swift
@@ -2,6 +2,19 @@ import Foundation
 import Observation
 import KeelhavenCore
 
+/// The retention choice as the picker sees it: which of the four, with the
+/// count held separately. Same split as `ScheduleKind` and `builtSchedule()`
+/// — a parameterised choice edits badly when the parameter lives inside the
+/// selection (issue #52).
+enum RetentionKind: String, CaseIterable, Identifiable {
+    case off
+    case year
+    case month
+    case lastN
+
+    var id: String { rawValue }
+}
+
 /// The four plan settings that are neither "what / where / when" nor a
 /// secret: verification cadence, retention, exclude patterns and restic's
 /// throughput knobs.
@@ -15,7 +28,14 @@ import KeelhavenCore
 final class PlanOptionsDraft {
     var excludePatterns: [String]
     var checkCadence: CheckCadence
-    var retention: RetentionPolicy
+    var retentionKind: RetentionKind
+    /// Held as text like the Advanced knobs, so a half-typed number never
+    /// snaps back under the cursor. Only read when `retentionKind` is
+    /// `.lastN`.
+    var keepLastText = ""
+    /// The floor `RetentionPolicy` clamps to, used when the field is empty
+    /// or unparseable — never zero, which would mean "delete everything".
+    private static let defaultKeepLast = 10
     /// The boolean `restic backup` switches (issues #46, #50). Off by
     /// default, like every other advanced setting here.
     var excludeCaches = false
@@ -40,13 +60,38 @@ final class PlanOptionsDraft {
     ) {
         self.excludePatterns = excludePatterns
         self.checkCadence = checkCadence
-        self.retention = retention
+        (self.retentionKind, self.keepLastText) = Self.editorComponents(for: retention)
+    }
+
+    /// The inverse of `builtRetention()`, for seeding the picker from a
+    /// stored plan — mirroring `Schedule.editorComponents`.
+    private static func editorComponents(for policy: RetentionPolicy) -> (RetentionKind, String) {
+        switch policy {
+        case .off: return (.off, String(defaultKeepLast))
+        case .year: return (.year, String(defaultKeepLast))
+        case .month: return (.month, String(defaultKeepLast))
+        case .lastN: return (.lastN, String(policy.keepLastCount ?? defaultKeepLast))
+        }
+    }
+
+    /// Anything unparseable falls back to the default count rather than to
+    /// zero: `RetentionPolicy` clamps too, but a policy that silently became
+    /// "keep nothing" is the one outcome worth guarding twice.
+    func builtRetention() -> RetentionPolicy {
+        switch retentionKind {
+        case .off: return .off
+        case .year: return .year
+        case .month: return .month
+        case .lastN:
+            let typed = Int(keepLastText.trimmingCharacters(in: .whitespaces))
+            return .lastN(typed ?? Self.defaultKeepLast)
+        }
     }
 
     func load(from plan: BackupPlan) {
         excludePatterns = plan.excludePatterns
         checkCadence = plan.checkCadence
-        retention = plan.retention
+        (retentionKind, keepLastText) = Self.editorComponents(for: plan.retention)
         excludeCaches = plan.backupOptions.excludeCaches
         oneFileSystem = plan.backupOptions.oneFileSystem
         noScan = plan.backupOptions.noScan

--- a/Keelhaven/Support/PlanOptionsUI.swift
+++ b/Keelhaven/Support/PlanOptionsUI.swift
@@ -86,27 +86,56 @@ struct VerificationSection: View {
 }
 
 /// How much snapshot history to keep. `off` — never delete — is the default.
+///
+/// A radio group rather than the segmented control the other choices use: a
+/// fourth option does not fit four readable English labels across one row,
+/// and one of them carries a number field beside it (issue #52). The same
+/// shape as the schedule step's frequency picker, which is the app's existing
+/// answer to "several choices, one of them parameterised".
 struct RetentionSection: View {
-    @Binding var retention: RetentionPolicy
+    @Bindable var options: PlanOptionsDraft
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Retention")
                 .font(.headline)
-            Picker("Retention", selection: $retention) {
-                Text("Keep everything").tag(RetentionPolicy.off)
-                Text("A year of history").tag(RetentionPolicy.year)
-                Text("A month of history").tag(RetentionPolicy.month)
+            Picker("Retention", selection: $options.retentionKind) {
+                Text("Keep everything").tag(RetentionKind.off)
+                Text("A year of history").tag(RetentionKind.year)
+                Text("A month of history").tag(RetentionKind.month)
+                Text("Keep a set number of backups").tag(RetentionKind.lastN)
             }
             .labelsHidden()
-            .pickerStyle(.segmented)
-            // Same reason as Verification above. English fills the 380 and
-            // hides it; Chinese ("保留全部" and friends) does not.
-            .frame(maxWidth: 380, alignment: .leading)
-            Text("Thins older snapshots to daily, weekly and monthly keepers and reclaims the space — after a backup, at most once a week. Keep everything never deletes a snapshot.")
+            .pickerStyle(.radioGroup)
+
+            // Only when it is the choice being made: an always-visible number
+            // beside three time presets would read as a fifth setting.
+            if options.retentionKind == .lastN {
+                HStack(spacing: 8) {
+                    Text("Keep the last")
+                    TextField("10", text: $options.keepLastText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 70)
+                    Text("backups")
+                }
+                .padding(.leading, 20)
+            }
+
+            Text(explanation)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// The presets and the count delete on different principles, so one
+    /// sentence cannot honestly cover both.
+    private var explanation: LocalizedStringKey {
+        switch options.retentionKind {
+        case .lastN:
+            return "Deletes everything older than that, however recent it is — a burst of backups in one day can push out the whole of last month. The space is reclaimed after a backup, at most once a week."
+        case .off, .year, .month:
+            return "Thins older snapshots to daily, weekly and monthly keepers and reclaims the space — after a backup, at most once a week. Keep everything never deletes a snapshot."
         }
     }
 }

--- a/Keelhaven/Wizard/ScheduleStepView.swift
+++ b/Keelhaven/Wizard/ScheduleStepView.swift
@@ -97,7 +97,7 @@ struct ScheduleStepView: View {
             if customizeExpanded {
                 VStack(alignment: .leading, spacing: 14) {
                     VerificationSection(cadence: $model.options.checkCadence)
-                    RetentionSection(retention: $model.options.retention)
+                    RetentionSection(options: model.options)
                     ExcludePatternsSection(options: model.options)
                     AdvancedPerformanceSection(options: model.options)
                 }

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -374,7 +374,7 @@ final class WizardModel {
             schedule: schedule,
             excludePatterns: options.excludePatterns,
             checkCadence: options.checkCadence,
-            retention: options.retention,
+            retention: options.builtRetention(),
             performance: options.builtPerformance(),
             backupOptions: options.builtBackupOptions(),
             firstBackupStartsOnCreation: firstBackupStartsOnCreation,

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/BackupPlan.swift
@@ -85,7 +85,12 @@ public struct BackupPlan: Codable, Identifiable, Hashable, Sendable {
         schedule = try container.decode(Schedule.self, forKey: .schedule)
         excludePatterns = try container.decode([String].self, forKey: .excludePatterns)
         checkCadence = try container.decodeIfPresent(CheckCadence.self, forKey: .checkCadence) ?? .weekly
-        retention = try container.decodeIfPresent(RetentionPolicy.self, forKey: .retention) ?? .off
+        // `try?`, unlike its neighbours: retention is the one field whose
+        // set of valid values can grow (issue #52 added `last:N`), so a plan
+        // written by a newer build must degrade to "keep everything" here
+        // rather than take the whole plan list down with it. Falling back to
+        // `.off` is the safe direction — it never deletes anything.
+        retention = (try? container.decodeIfPresent(RetentionPolicy.self, forKey: .retention)) ?? .off
         performance = try container.decodeIfPresent(PerformanceOptions.self, forKey: .performance) ?? .off
         backupOptions = try container.decodeIfPresent(BackupOptions.self, forKey: .backupOptions) ?? .off
         // Absent on every plan written before this flag existed — and those

--- a/KeelhavenCore/Sources/KeelhavenCore/Models/RetentionPolicy.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Models/RetentionPolicy.swift
@@ -1,18 +1,42 @@
 import Foundation
 
-/// How much snapshot history a plan keeps — presets rather than free-form
-/// keep counts, so retention stays a choice a person can read instead of
-/// five numeric fields. `off` means Keelhaven never deletes a snapshot and
-/// is the default: deletion is strictly opt-in. The presets map to restic's
-/// `forget --keep-*` flags; both keep the three most recent snapshots
-/// unconditionally so a burst of runs can never thin away everything recent.
-public enum RetentionPolicy: String, Codable, CaseIterable, Hashable, Sendable {
+/// How much snapshot history a plan keeps. `off` means Keelhaven never
+/// deletes a snapshot and is the default: deletion is strictly opt-in.
+///
+/// Three of the four choices are presets rather than free-form keep counts,
+/// so retention stays something a person can read instead of five numeric
+/// fields. They map to restic's `forget --keep-*` flags, and both keep the
+/// three most recent snapshots unconditionally so a burst of runs can never
+/// thin away everything recent.
+///
+/// `lastN` is the one count anyone asked for (issue #52): keep the last N
+/// backups and nothing else, which is a shape no time-based preset can
+/// express. It is deliberately the only parameterised case — the doc comment
+/// above is a rule, not a description, and a second number field would break
+/// it.
+///
+/// No longer `String`-backed or `CaseIterable`: neither survives an
+/// associated value, and nothing used them (the picker tags each case by
+/// hand). `Codable` is written out below instead, and still reads every value
+/// written before this case existed.
+public enum RetentionPolicy: Codable, Hashable, Sendable {
     /// Keep every snapshot.
     case off
     /// About a year of history: 7 daily, 5 weekly, 12 monthly keepers.
     case year
     /// About a month of history: 7 daily, 4 weekly keepers.
     case month
+    /// Keep the last `count` backups and nothing else.
+    ///
+    /// The payload is not trusted anywhere it matters: `keepArguments`
+    /// clamps it, so a hand-edited `plans.json` cannot produce a `forget`
+    /// restic refuses — or worse, one that keeps nothing.
+    case lastN(Int)
+
+    /// What `lastN` accepts. One is the floor because zero would mean
+    /// "delete every snapshot", which no retention setting should be able to
+    /// say; the ceiling only keeps the argument sane.
+    public static let keepLastRange = 1...999
 
     /// The `restic forget` keep flags for this policy. Empty for `.off`,
     /// which callers must treat as "never run forget" — restic rejects a
@@ -34,6 +58,58 @@ public enum RetentionPolicy: String, Codable, CaseIterable, Hashable, Sendable {
                 "--keep-daily", "7",
                 "--keep-weekly", "4",
             ]
+        case .lastN(let count):
+            return ["--keep-last", String(Self.clamped(count))]
         }
+    }
+
+    /// The count this policy keeps, already clamped — nil for the presets,
+    /// which have no single number to show.
+    public var keepLastCount: Int? {
+        guard case .lastN(let count) = self else { return nil }
+        return Self.clamped(count)
+    }
+
+    private static func clamped(_ count: Int) -> Int {
+        min(max(count, keepLastRange.lowerBound), keepLastRange.upperBound)
+    }
+
+    // MARK: - Codable
+
+    /// Encoded as a single string, so `plans.json` stays readable and the
+    /// field keeps the shape it has always had: `off`, `year`, `month`, or
+    /// `last:10`.
+    private var encodedValue: String {
+        switch self {
+        case .off: return "off"
+        case .year: return "year"
+        case .month: return "month"
+        case .lastN(let count): return "last:\(Self.clamped(count))"
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        switch raw {
+        case "off":
+            self = .off
+        case "year":
+            self = .year
+        case "month":
+            self = .month
+        default:
+            guard raw.hasPrefix("last:"), let count = Int(raw.dropFirst(5)) else {
+                throw DecodingError.dataCorrupted(
+                    .init(codingPath: decoder.codingPath,
+                          debugDescription: "Unrecognised retention policy: \(raw)")
+                )
+            }
+            self = .lastN(Self.clamped(count))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(encodedValue)
     }
 }

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ModelRoundTripTests.swift
@@ -278,4 +278,85 @@ final class ModelRoundTripTests: XCTestCase {
         XCTAssertNil(record.skippedUnchanged)
         XCTAssertNotEqual(record.skippedUnchanged, true)
     }
+
+    /// Every value written before `lastN` existed must still read back
+    /// exactly, and the new one must survive a save/load (issue #52).
+    func testRetentionPolicyCodingCoversOldAndNewValues() throws {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+
+        for (json, expected) in [
+            (#""off""#, RetentionPolicy.off),
+            (#""year""#, RetentionPolicy.year),
+            (#""month""#, RetentionPolicy.month),
+            (#""last:10""#, RetentionPolicy.lastN(10)),
+        ] {
+            let data = try XCTUnwrap(json.data(using: .utf8))
+            XCTAssertEqual(try decoder.decode(RetentionPolicy.self, from: data), expected)
+        }
+
+        // The presets keep the exact strings they have always been written
+        // as, so a plans.json written by this build stays readable by hand.
+        for (policy, json) in [
+            (RetentionPolicy.off, #""off""#),
+            (RetentionPolicy.year, #""year""#),
+            (RetentionPolicy.month, #""month""#),
+            (RetentionPolicy.lastN(10), #""last:10""#),
+        ] {
+            XCTAssertEqual(String(decoding: try encoder.encode(policy), as: UTF8.self), json)
+        }
+
+        // A count out of range is clamped on the way in, not carried.
+        let wild = try XCTUnwrap(#""last:0""#.data(using: .utf8))
+        XCTAssertEqual(try decoder.decode(RetentionPolicy.self, from: wild), .lastN(1))
+    }
+
+    func testUnrecognisedRetentionPolicyIsRejectedByTheType() throws {
+        let decoder = JSONDecoder()
+        for json in [#""weekly""#, #""last:""#, #""last:abc""#, #""""#] {
+            let data = try XCTUnwrap(json.data(using: .utf8))
+            XCTAssertThrowsError(try decoder.decode(RetentionPolicy.self, from: data), json)
+        }
+    }
+
+    /// …but a plan carrying one must still load. Retention is the one field
+    /// whose valid values can grow, so an unreadable one degrades to "keep
+    /// everything" rather than taking the whole plan list down.
+    func testAPlanWithAnUnreadableRetentionStillLoadsAsKeepEverything() throws {
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .daily(hour: 21, minute: 30),
+            retention: .month,
+            createdAt: date
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoder.encode(plan)) as? [String: Any]
+        )
+        // What a build two versions from now might write here.
+        object["retention"] = "keep-hourly:24"
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupPlan.self, from: data)
+        XCTAssertEqual(decoded.retention, .off, "The safe direction: never delete")
+        XCTAssertEqual(decoded.name, plan.name, "The rest of the plan must survive")
+    }
+
+    func testKeepLastSurvivesAPlanRoundTrip() throws {
+        let plan = BackupPlan(
+            name: "Documents",
+            sourcePaths: ["/Users/me/Documents"],
+            destination: .local(path: "/Volumes/Backup/repo"),
+            schedule: .hourly,
+            retention: .lastN(25),
+            createdAt: date
+        )
+        XCTAssertEqual(try roundTrip(plan).retention, .lastN(25))
+    }
 }
+

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/PrunePolicyTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/PrunePolicyTests.swift
@@ -56,3 +56,65 @@ final class PrunePolicyTests: XCTestCase {
         XCTAssertTrue(PrunePolicy.isDue(plan, now: failedAt.addingTimeInterval(week)))
     }
 }
+
+/// `RetentionPolicy.lastN` — the one policy whose behaviour is chosen by a
+/// number a person types, so the tests are mostly about what happens when
+/// that number is wrong (issue #52).
+final class RetentionKeepLastTests: XCTestCase {
+    func testKeepLastRendersOnlyTheCountFlag() {
+        XCTAssertEqual(RetentionPolicy.lastN(10).keepArguments, ["--keep-last", "10"])
+        XCTAssertEqual(RetentionPolicy.lastN(1).keepArguments, ["--keep-last", "1"])
+    }
+
+    /// The presets are unchanged — this case must not have altered them.
+    func testPresetsAreUntouched() {
+        XCTAssertEqual(RetentionPolicy.off.keepArguments, [])
+        XCTAssertEqual(
+            RetentionPolicy.year.keepArguments,
+            ["--keep-last", "3", "--keep-daily", "7", "--keep-weekly", "5", "--keep-monthly", "12"]
+        )
+        XCTAssertEqual(
+            RetentionPolicy.month.keepArguments,
+            ["--keep-last", "3", "--keep-daily", "7", "--keep-weekly", "4"]
+        )
+    }
+
+    /// The assertion that matters most: no count, however wrong, may render a
+    /// `forget` that keeps nothing. Zero and negatives clamp up to one.
+    func testAnOutOfRangeCountCanNeverKeepNothing() {
+        for count in [0, -1, Int.min + 1] {
+            let arguments = RetentionPolicy.lastN(count).keepArguments
+            XCTAssertEqual(arguments, ["--keep-last", "1"], "count \(count) must clamp to the floor")
+            XCTAssertFalse(arguments.isEmpty, "an empty policy would make restic refuse or delete")
+        }
+        XCTAssertEqual(RetentionPolicy.lastN(Int.max).keepArguments, ["--keep-last", "999"])
+        XCTAssertEqual(RetentionPolicy.lastN(1000).keepArguments, ["--keep-last", "999"])
+    }
+
+    func testKeepLastCountReportsTheClampedValueAndNilForPresets() {
+        XCTAssertEqual(RetentionPolicy.lastN(10).keepLastCount, 10)
+        XCTAssertEqual(RetentionPolicy.lastN(0).keepLastCount, 1)
+        XCTAssertNil(RetentionPolicy.off.keepLastCount)
+        XCTAssertNil(RetentionPolicy.year.keepLastCount)
+        XCTAssertNil(RetentionPolicy.month.keepLastCount)
+    }
+
+    /// `.lastN` must be due for a prune like any other deleting policy, and
+    /// `.off` must still never be.
+    func testKeepLastIsSubjectToThePrunePolicy() {
+        let created = Date(timeIntervalSince1970: 1_755_000_000)
+        func plan(_ retention: RetentionPolicy) -> BackupPlan {
+            BackupPlan(
+                name: "Test",
+                sourcePaths: ["/tmp/src"],
+                destination: .local(path: "/tmp/repo"),
+                schedule: .daily(hour: 21, minute: 0),
+                retention: retention,
+                createdAt: created
+            )
+        }
+        let later = created.addingTimeInterval(30 * 24 * 3600)
+        XCTAssertTrue(PrunePolicy.isDue(plan(.lastN(10)), now: later))
+        XCTAssertFalse(PrunePolicy.isDue(plan(.off), now: later))
+    }
+}

--- a/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
+++ b/KeelhavenCore/Tests/KeelhavenCoreTests/ResticRunnerIntegrationTests.swift
@@ -819,5 +819,71 @@ final class ResticRunnerIntegrationTests: XCTestCase {
             XCTAssertEqual(status.percentDone, 0, "--no-scan must not report progress")
         }
     }
+
+    /// `keep the last N` against the real binary. A retention setting is the
+    /// only thing in the app that deletes, so "it renders the right flag" is
+    /// not enough — this makes five snapshots, keeps two, and counts what is
+    /// left (issue #52).
+    func testKeepLastActuallyLeavesOnlyThatManySnapshots() async throws {
+        guard let binary = IntegrationTestSupport.locateRestic() else {
+            throw XCTSkip("restic is not installed; run: brew install restic")
+        }
+
+        let repoURL = workDirectory.appendingPathComponent("repo", isDirectory: true)
+        let sourceURL = workDirectory.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let destination = Destination.local(path: repoURL.path)
+        let credentials = RepoCredentials(repositoryPassword: "integration-test-password")
+        let runner = ResticRunner(binaryURL: binary)
+        _ = try await runner.run(
+            .initRepository,
+            destination: destination,
+            credentials: credentials,
+            decoding: ResticInitResult.self
+        )
+
+        // Five distinct snapshots: each run changes a file, so none is skipped.
+        for index in 0..<5 {
+            try Data("revision \(index)\n".utf8)
+                .write(to: sourceURL.appendingPathComponent("a.txt"))
+            let stream = runner.backupStream(
+                .backup(
+                    sources: [sourceURL.path], excludes: [], tag: "keelhaven-test",
+                    performance: .off, options: .off
+                ),
+                destination: destination,
+                credentials: credentials
+            )
+            for try await _ in stream {}
+        }
+
+        func snapshotCount() async throws -> Int {
+            try await runner.run(
+                .snapshots,
+                destination: destination,
+                credentials: credentials,
+                decoding: [ResticSnapshot].self
+            ).count
+        }
+        let before = try await snapshotCount()
+        XCTAssertEqual(before, 5)
+
+        try await runner.runIgnoringOutput(
+            .forget(retention: .lastN(2), performance: .off),
+            destination: destination,
+            credentials: credentials
+        )
+
+        let after = try await snapshotCount()
+        XCTAssertEqual(after, 2, "keep the last 2 must leave exactly two snapshots")
+
+        // And the repository is still sound after the prune rewrote it.
+        try await runner.runIgnoringOutput(
+            .check,
+            destination: destination,
+            credentials: credentials
+        )
+    }
 }
 


### PR DESCRIPTION
Fixes #52

Branched from `main` at 15543c3.

## Why

A user's entire retention policy on the command line was `--keep-last`, and Keelhaven could not express it: all three presets thin to daily/weekly/monthly keepers, so *"keep the last 10 and nothing else"* was unreachable.

## The model decision the issue delegated

The issue said the implementer should pick between an associated value on `RetentionPolicy` and a separate count field on `BackupPlan`, and say which. **Associated value.**

A policy that could not answer `keepArguments` on its own would spread one decision across two fields and let them disagree — `ResticCommand.forget` takes the policy, not the plan, and it would have had to grow a second parameter that only one case uses.

The cost that argument usually carries did not apply here, and I checked before deciding:

- **`CaseIterable` is used nowhere** in the repo.
- The picker **tags each case by hand** (`.tag(RetentionPolicy.off)`), so it never needed `allCases` either.
- `PrunePolicy`'s `plan.retention != .off` needs only `Equatable`, which synthesises fine with a payload.

So dropping the `String` raw value and the synthesised `Codable` touched nothing. `Codable` is written out instead and still reads every value ever stored. Encoding stays a **single string** — `off`, `year`, `month`, `last:10` — so `plans.json` remains readable by hand and the field keeps the shape it has always had.

## Two safety properties worth calling out

**A policy can never keep nothing.** The count is clamped to `1...999` inside `keepArguments`, not trusted from the payload, so no hand-edited `plans.json` and no future caller can produce a `forget` that deletes everything. A test walks `0`, `-1` and `Int.min + 1` and asserts they all clamp to `--keep-last 1`.

**Retention is now the one field whose set of valid values can grow.** `BackupPlan` therefore decodes it with `try?` and falls back to `.off`, so a plan written by a *newer* build degrades to "keep everything" rather than taking the whole plan list down — and that fallback is the safe direction, because it never deletes. There is a test for it.

⚠️ The converse is worth knowing: a plan saved with `last:N` and then opened by **0.8.x or earlier** will fail to decode there, and that build has no such fallback. Downgrading after using this setting would show "Could not load backup plans". Nothing in this PR can fix an already-released build; flagging it in case you would rather ship the fallback first and the feature later.

## UI

The picker becomes a **radio group**. Four readable English labels do not fit across one segmented row, and one of them carries a number field beside it. The schedule step already answers "several choices, one of them parameterised" the same way, so this is an existing pattern rather than a new one.

The field appears only when that choice is selected, and the explanation changes with it — a count deletes on a different principle from the time presets (*"a burst of backups in one day can push out the whole of last month"*), and one sentence cannot honestly cover both.

The draft splits into `retentionKind` + `keepLastText`, mirroring `ScheduleKind` + `builtSchedule()`.

## Verification

- **169 tests, 0 failures.** Line coverage stays 100% on KeelhavenCore; `RetentionPolicy.swift` and `BackupPlan.swift` are both 100%.
- **Real restic, end to end** — five snapshots made, `forget` with `keep-last 2`, **exactly two left**, and `restic check` passes afterwards. A retention setting is the only thing in the app that deletes, so "it renders the right flag" was not enough.
- **Coding** — every legacy value (`off`/`year`/`month`) decodes and re-encodes byte-identically; `last:10` round-trips; `last:0` clamps on the way in; unrecognised strings throw at the type but still load as `.off` at the plan.
- **Runtime, isolated `HOME`** — a plan seeded as `"retention": "last:25"` opens with the fourth option selected and **25** in the field, proving the string ↔ UI path; switching to a preset hides the field and swaps the explanation. Screenshotted.
- Localization cross-checked against Xcode's extracted `.stringsdata`; the three new sentences ship with Simplified Chinese, and the numeric placeholder is marked `shouldTranslate: false` like the existing ones.

**Not screenshotted:** the Chinese rendering of this section — the test instance's accessibility connection kept dropping late in the run. The strings are verified present and it is the same shared view that has been screenshotted in Chinese for the other option sections. Say the word and I will attach it.