### PR TITLE
Keep the plan panel a steady height, and put a number on the progress bar

### DIFF
--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -407,6 +407,16 @@
         }
       }
     },
+    "Backing up…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在备份…"
+          }
+        }
+      }
+    },
     "Backup %lld percent done": {
       "localizations": {
         "zh-Hans": {
@@ -787,16 +797,6 @@
         }
       }
     },
-    "Daily at %@": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每天 %@"
-          }
-        }
-      }
-    },
     "Date": {
       "localizations": {
         "zh-Hans": {
@@ -1027,12 +1027,52 @@
         }
       }
     },
+    "Every day": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每天"
+          }
+        }
+      }
+    },
+    "Every day at %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每天 %@"
+          }
+        }
+      }
+    },
     "Every hour": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "每小时"
+          }
+        }
+      }
+    },
+    "Every week": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每周"
+          }
+        }
+      }
+    },
+    "Every week on %@ at %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每%1$@ %2$@"
           }
         }
       }
@@ -1596,26 +1636,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "星期"
-          }
-        }
-      }
-    },
-    "Once a day": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每天一次"
-          }
-        }
-      }
-    },
-    "Once a week": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每周一次"
           }
         }
       }
@@ -2526,16 +2546,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "每周"
-          }
-        }
-      }
-    },
-    "Weekly on %@ at %@": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每%1$@ %2$@"
           }
         }
       }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -396,23 +396,42 @@ struct PlanStatusRow: View {
         switch runState {
         case .running(let progress, let bytesDone):
             if let progress {
-                ProgressView(value: progress)
-                    .controlSize(.small)
-                    .padding(.top, 2)
-                    .accessibilityLabel(String(localized: "Backup \(Int(progress * 100)) percent done"))
+                // A bar needs the row's whole width, so it keeps its own line
+                // — but the number it represents rides along on that line
+                // instead of leaving the bar to speak for itself.
+                HStack(spacing: 6) {
+                    ProgressView(value: progress)
+                        .controlSize(.small)
+                    Text(progress.formatted(.percent.precision(.fractionLength(0))))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                .padding(.top, 2)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(String(localized: "Backup \(Int(progress * 100)) percent done"))
             } else {
                 // No percentage to show — `--no-scan` means restic never
-                // measured the sources (issue #51). The bar spins and the
-                // amount copied stands in for it, which is the honest answer
-                // rather than a bar frozen at zero.
-                VStack(alignment: .leading, spacing: 4) {
-                    if let bytesDone {
-                        Text("\(Self.formatted(bytesDone)) backed up so far")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
+                // measured the sources (issue #51). The spinner stands in for
+                // the bar and the amount copied for the percentage, which is
+                // the honest answer rather than a bar frozen at zero. It sits
+                // to the left of its caption, like `.checking` / `.pruning` /
+                // `.unlocking` below — a spinner is a glyph, not a row.
+                HStack(spacing: 6) {
                     ProgressView()
                         .controlSize(.small)
+                    Group {
+                        if let bytesDone {
+                            Text("\(Self.formatted(bytesDone)) backed up so far")
+                        } else {
+                            // The opening seconds of every run land here,
+                            // before restic has reported a byte. Say so rather
+                            // than leave the spinner captioned by nothing.
+                            Text("Backing up…")
+                        }
+                    }
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
                 }
                 .padding(.top, 2)
                 .accessibilityElement(children: .ignore)
@@ -422,19 +441,32 @@ struct PlanStatusRow: View {
                 )
             }
         case .previewing(let progress):
-            // Deliberately not a bare progress bar like `.running`: the two
-            // would be indistinguishable, and someone glancing at the panel
-            // would think a backup was being written.
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Previewing what would be backed up…")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+            // Deliberately always captioned, unlike `.running`: an uncaptioned
+            // bar would be indistinguishable from a real backup, and someone
+            // glancing at the panel would think one was being written.
+            Group {
                 if let progress {
-                    ProgressView(value: progress)
-                        .controlSize(.small)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Previewing what would be backed up…")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        HStack(spacing: 6) {
+                            ProgressView(value: progress)
+                                .controlSize(.small)
+                            Text(progress.formatted(.percent.precision(.fractionLength(0))))
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                    }
                 } else {
-                    ProgressView()
-                        .controlSize(.small)
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Previewing what would be backed up…")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .accessibilityElement(children: .ignore)
@@ -473,9 +505,13 @@ struct PlanStatusRow: View {
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(String(localized: "Unlocking repository"))
         case .failed(let message):
+            // restic's errors run to arbitrary length; three lines is enough
+            // to recognise one without letting it stretch the panel. The
+            // tooltip already carries the full text.
             Text(message)
                 .font(.callout)
                 .foregroundStyle(.red)
+                .lineLimit(3)
                 .help(message)
         case .failedLocked(let message):
             // restic's own three lines of PID-and-hostname detail stay in the

--- a/Keelhaven/Support/ScheduleUI.swift
+++ b/Keelhaven/Support/ScheduleUI.swift
@@ -48,19 +48,21 @@ extension Schedule {
         }
     }
 
-    /// "Every hour" / "Daily at 21:00" / "Weekly on Sunday at 21:00",
-    /// following the user's locale and 12/24-hour preference.
+    /// "Every hour" / "Every day at 21:00" / "Every week on Sunday at 21:00" —
+    /// the same three words the frequency picker uses, so the row and the
+    /// editor never describe one schedule two ways. Follows the user's locale
+    /// and 12/24-hour preference.
     var displayText: String {
         switch self {
         case .hourly:
             return String(localized: "Every hour")
         case .daily:
             let time = editorComponents.dailyTime.formatted(date: .omitted, time: .shortened)
-            return String(localized: "Daily at \(time)")
+            return String(localized: "Every day at \(time)")
         case .weekly(let weekday, _, _):
             let time = editorComponents.dailyTime.formatted(date: .omitted, time: .shortened)
             let day = Self.weekdayName(weekday)
-            return String(localized: "Weekly on \(day) at \(time)")
+            return String(localized: "Every week on \(day) at \(time)")
         }
     }
 
@@ -87,30 +89,41 @@ struct ScheduleEditor: View {
     }
 
     var body: some View {
-        Picker("Frequency", selection: $kind) {
-            ForEach(ScheduleKind.allCases) { kind in
-                Text(kind.localizedTitle).tag(kind)
-            }
-        }
-        .pickerStyle(.radioGroup)
-        .labelsHidden()
-
-        if kind == .weekly {
-            Picker("On", selection: $weekday) {
-                ForEach(orderedWeekdays, id: \.self) { day in
-                    Text(Schedule.weekdayName(day)).tag(day)
+        // The weekday and time-of-day controls sit in a column beside the
+        // radios rather than stacked under them. That saves a row — two in
+        // weekly mode — and, more usefully, keeps this section exactly three
+        // rows tall at every frequency, so changing the frequency no longer
+        // makes everything below it jump.
+        HStack(alignment: .center, spacing: 20) {
+            Picker("Frequency", selection: $kind) {
+                ForEach(ScheduleKind.allCases) { kind in
+                    Text(kind.localizedTitle).tag(kind)
                 }
             }
-            .frame(maxWidth: 200)
-        }
+            .pickerStyle(.radioGroup)
+            .labelsHidden()
 
-        if kind != .hourly {
-            DatePicker(
-                "At",
-                selection: $dailyTime,
-                displayedComponents: .hourAndMinute
-            )
-            .frame(maxWidth: 200)
+            // Hourly needs neither control, and they are removed from the
+            // hierarchy rather than disabled — so whenever this column is on
+            // screen, the frequency it qualifies is the one that is selected.
+            if kind != .hourly {
+                VStack(alignment: .leading, spacing: 8) {
+                    if kind == .weekly {
+                        Picker("On", selection: $weekday) {
+                            ForEach(orderedWeekdays, id: \.self) { day in
+                                Text(Schedule.weekdayName(day)).tag(day)
+                            }
+                        }
+                    }
+
+                    DatePicker(
+                        "At",
+                        selection: $dailyTime,
+                        displayedComponents: .hourAndMinute
+                    )
+                }
+                .fixedSize()
+            }
         }
     }
 }

--- a/Keelhaven/Support/ScheduleUI.swift
+++ b/Keelhaven/Support/ScheduleUI.swift
@@ -81,6 +81,10 @@ struct ScheduleEditor: View {
     @Binding var dailyTime: Date
     @Binding var weekday: Int
 
+    /// The height of the tallest row (the weekly one, whose pop-up button is
+    /// taller than a radio or a time field), applied to all three.
+    private let rowHeight: CGFloat = 24
+
     /// Weekday numbers in the user's regional order (e.g. Monday-first in
     /// most of Europe and China), tagging the real Calendar weekday values.
     private var orderedWeekdays: [Int] {
@@ -89,41 +93,71 @@ struct ScheduleEditor: View {
     }
 
     var body: some View {
-        // The weekday and time-of-day controls sit in a column beside the
-        // radios rather than stacked under them. That saves a row — two in
-        // weekly mode — and, more usefully, keeps this section exactly three
-        // rows tall at every frequency, so changing the frequency no longer
-        // makes everything below it jump.
-        HStack(alignment: .center, spacing: 20) {
+        // A vertical radio list where each frequency's qualifying controls sit
+        // on that frequency's own row, and only while it is the selected one.
+        // Stacking them under the group made the section one row tall on
+        // hourly, two on daily and three on weekly, so changing your mind slid
+        // every section below it up or down; here it is always three rows, and
+        // whatever is on screen reads as one sentence with the frequency it
+        // belongs to.
+        VStack(alignment: .leading, spacing: 8) {
+            frequencyRow(.hourly) {}
+            frequencyRow(.daily) {
+                timePicker
+            }
+            frequencyRow(.weekly) {
+                weekdayPicker
+                timePicker
+            }
+        }
+        // A radio per row means three one-option radio groups rather than one
+        // group of three; containing them keeps VoiceOver reading the choices
+        // for one setting as a single cluster.
+        .accessibilityElement(children: .contain)
+    }
+
+    /// One radio and, when it is the chosen one, the controls that qualify it.
+    private func frequencyRow(
+        _ rowKind: ScheduleKind,
+        @ViewBuilder controls: () -> some View
+    ) -> some View {
+        HStack(spacing: 12) {
+            // One single-option picker per row, all three bound to the same
+            // selection: it behaves as one radio group, but gives each radio a
+            // row of its own to hang controls off. A single `.radioGroup`
+            // Picker owns its whole layout and can only be stacked around.
             Picker("Frequency", selection: $kind) {
-                ForEach(ScheduleKind.allCases) { kind in
-                    Text(kind.localizedTitle).tag(kind)
-                }
+                Text(rowKind.localizedTitle).tag(rowKind)
             }
             .pickerStyle(.radioGroup)
             .labelsHidden()
 
-            // Hourly needs neither control, and they are removed from the
-            // hierarchy rather than disabled — so whenever this column is on
-            // screen, the frequency it qualifies is the one that is selected.
-            if kind != .hourly {
-                VStack(alignment: .leading, spacing: 8) {
-                    if kind == .weekly {
-                        Picker("On", selection: $weekday) {
-                            ForEach(orderedWeekdays, id: \.self) { day in
-                                Text(Schedule.weekdayName(day)).tag(day)
-                            }
-                        }
-                    }
-
-                    DatePicker(
-                        "At",
-                        selection: $dailyTime,
-                        displayedComponents: .hourAndMinute
-                    )
-                }
-                .fixedSize()
+            if kind == rowKind {
+                controls()
             }
         }
+        // A row is as tall as whatever control it carries — a bare radio, a
+        // time field, a pop-up button — so without a floor the section would
+        // still breathe a couple of points as the frequency changed. The floor
+        // is the tallest of the three.
+        .frame(minHeight: rowHeight, alignment: .leading)
+    }
+
+    private var weekdayPicker: some View {
+        Picker("On", selection: $weekday) {
+            ForEach(orderedWeekdays, id: \.self) { day in
+                Text(Schedule.weekdayName(day)).tag(day)
+            }
+        }
+        .fixedSize()
+    }
+
+    private var timePicker: some View {
+        DatePicker(
+            "At",
+            selection: $dailyTime,
+            displayedComponents: .hourAndMinute
+        )
+        .fixedSize()
     }
 }

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -30,8 +30,8 @@ enum ScheduleKind: String, CaseIterable, Identifiable {
     var localizedTitle: String {
         switch self {
         case .hourly: return String(localized: "Every hour")
-        case .daily: return String(localized: "Once a day")
-        case .weekly: return String(localized: "Once a week")
+        case .daily: return String(localized: "Every day")
+        case .weekly: return String(localized: "Every week")
         }
     }
 }


### PR DESCRIPTION
Two places where the panel changed size as you looked at it, plus one wording
mismatch that fell out of fixing them.

### The schedule editor held a different height at every frequency

It stacked the weekday and time-of-day controls *under* the radio group, so
the Schedule section was one row tall on **Every hour**, two on **Every day**
and three on **Every week** — 132pt, 168pt, 206pt. Changing your mind in the
Edit Plan window slid Verification, Retention, Destination and everything
below it up or down.

Those two controls now sit on the selected radio's **own row** — "Every day
At 21:00", "Every week On Sunday At 21:00" — so the section is a flat three
rows (158pt) at every frequency, and each control reads as one sentence with
the frequency it qualifies rather than floating beside the group. Rows that
are not selected carry nothing, so the only time on screen is the one that is
in force. Every row is floored at the height of the tallest control, so the
weekly pop-up button doesn't add two points of its own.

That means three one-option pickers bound to one selection rather than a
single radio group: SwiftUI's `.radioGroup` owns its whole layout, so a group
can only be stacked around, never interleaved. Each keeps the hidden
"Frequency" label for accessibility and the three are wrapped in one
container, so VoiceOver still reads them as the choices for one setting.

This is one of the things behind #39's first complaint (the Edit Plan sheet
being taller than the screen). It doesn't close that issue on its own — it
takes 48pt off the tallest case and stops the section moving at all.

### The running row never said how far along it was

- A determinate bar told you a backup was in progress but never the number it
  represented. It now carries its percentage alongside, monospaced so it
  doesn't jitter.
- The `--no-scan` case (#51) stacked its caption *above* a spinner. Every
  other spinner state — `.checking`, `.pruning`, `.unlocking` — puts the
  spinner to the left of its caption, because a spinner is a glyph, not a row.
  It now matches.
- The opening seconds of a no-scan run, before restic reports a byte, showed
  a spinner captioned by nothing at all. It now says "Backing up…".
- `.previewing` gets the same percentage treatment, and stays captioned in
  both branches — an uncaptioned bar there would look exactly like a real
  backup being written.
- A failed row caps restic's arbitrarily long error at three lines. Enough to
  recognise which failure it is without letting it stretch the panel; the
  tooltip still carries the whole text.

### One schedule, two descriptions

The frequency picker said "Once a day" while the plan row said "Daily at
21:00" for the same setting. Both now say **Every day** / **Every week**,
matching "Every hour", which already agreed with itself.

## Testing

- `swift test --package-path KeelhavenCore` — 169 pass (3 network-backend
  skips locally; CI runs them).
- `xcodebuild ... build` — succeeds.
- `ScheduleEditor` rendered standalone at all three frequencies, in English
  and zh-Hans, in a harness reproducing the Edit Plan container. Measured the
  section at 158pt in all three, against 132/168/206 before; clicked every
  radio and confirmed the selection moves and the controls follow it.
- No core code changed, so the coverage gate is untouched.
- No new strings: the row reuses "On" / "At" / "Frequency", all already
  translated. The five changed strings are translated in `Localizable.xcstrings`
  and the four retired keys are gone with nothing referencing them.
