### PR TITLE
Show the demo's running row as the app actually draws it

### DIFF
--- a/site/.vitepress/theme/components/MenuBarDemo.vue
+++ b/site/.vitepress/theme/components/MenuBarDemo.vue
@@ -8,11 +8,12 @@ import { useData, withBase } from 'vitepress'
 // recreation honest in every language.
 const defaults = {
   ariaLabel:
-    'Animated demo of the Keelhaven menu bar app running a backup: a plan named Documents is backed up to an external drive, showing a small progress bar and its percentage while running, then a Backup complete notification.',
+    'Animated demo of the Keelhaven menu bar app running a backup: a plan named Documents is backed up to an external drive, showing a spinner while the engine starts, then a small progress bar with its percentage, then a Backup complete notification.',
   clock: 'Mon 9:41 AM',
   plan1Name: 'Documents',
   plan1Sched: 'Every day at 9:00 AM',
   plan1StatusIdle: 'Backed up 2 hours ago',
+  plan1StatusStarting: 'Backing up…',
   plan1StatusDone: 'Backed up 1 second ago',
   plan2Name: 'Photos',
   plan2Sched: 'Every hour',
@@ -36,9 +37,10 @@ const t = computed(() => ({
   <!-- An animated recreation of the real menu bar popover, drawn from the
        SwiftUI sources (MenuBarView / PlanStatusRow) so it can't drift into
        showing UI the app doesn't have. Pure CSS, one ~12s loop: idle → the
-       cursor clicks Back Up Now → the progress bar and its percentage run →
-       done, with the completion notification the app actually posts. All
-       timing lives in landing.css under .kh-demo-*. -->
+       cursor clicks Back Up Now → the spinner the app shows before restic
+       reports anything → the bar and its percentage → done, with the
+       completion notification the app actually posts. All timing lives in
+       landing.css under .kh-demo-*. -->
   <div class="kh-demo" role="img"
        :aria-label="t.ariaLabel">
 
@@ -49,8 +51,9 @@ const t = computed(() => ({
       <span class="kh-demo-mb-slot">
         <!-- design/svg/menubar.svg — the app's template glyph, verbatim -->
         <svg class="kh-demo-mb-idle" width="17" height="17" viewBox="0 0 36 36"><g fill="currentColor"><path d="M 11.8,12.4 C 12.2,8.3 14.7,5.2 18,5.2 C 21.3,5.2 23.8,8.3 24.2,12.4 Z"/><rect x="13.7" y="12.4" width="8.6" height="6.4"/><rect x="10.2" y="18.8" width="15.6" height="3.1" rx="1.3"/><path d="M 13.9,21.9 h 8.2 C 22.6,25.2 23.4,28.2 24.2,30.4 h -12.4 C 12.6,28.2 13.4,25.2 13.9,21.9 Z"/><rect x="8.6" y="30.1" width="18.8" height="3.4" rx="1.5"/></g></svg>
-        <!-- arrow.triangle.2.circlepath stand-in while a backup runs -->
-        <svg class="kh-demo-mb-busy" width="17" height="17" viewBox="0 0 24 24"><g class="kh-demo-mb-busy-spin" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M 20 12 A 8 8 0 1 1 12 4"/><path d="M 8.6 1.6 L 12.6 4.1 L 9.6 7.6"/></g></svg>
+        <!-- arrow.triangle.2.circlepath stand-in while a backup runs. Still,
+             like the symbol the app swaps in: it changes, it doesn't spin. -->
+        <svg class="kh-demo-mb-busy" width="17" height="17" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M 20 12 A 8 8 0 1 1 12 4"/><path d="M 8.6 1.6 L 12.6 4.1 L 9.6 7.6"/></g></svg>
       </span>
       <span class="kh-demo-mb-clock">{{ t.clock }}</span>
     </div>
@@ -83,9 +86,34 @@ const t = computed(() => ({
           <div class="kh-demo-statusline">
             <span class="kh-demo-status kh-demo-status-idle">{{ t.plan1StatusIdle }}</span>
             <span class="kh-demo-status kh-demo-status-done">{{ t.plan1StatusDone }}</span>
-            <!-- The bar and the number it stands for share a line, as they
-                 do in PlanStatusRow: a determinate bar that never says how
-                 far along it is leaves the reader guessing. -->
+            <!-- Where every run starts. `runBackup` sets the row running
+                 before restic has said anything, and restic reports nothing
+                 until it has measured something to divide by — so there is
+                 no percentage yet, and the app says so with a spinner and
+                 this caption rather than a bar sitting at zero. A short
+                 incremental run never gets past this state. -->
+            <span class="kh-demo-starting">
+              <!-- The indeterminate spinner, spokes and all, as ProgressView()
+                   draws it at .controlSize(.small). -->
+              <svg class="kh-demo-spinner" width="13" height="13" viewBox="0 0 16 16"
+                   fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+                <g class="kh-demo-spinner-spokes">
+                  <path d="M8 1.7V4.3" opacity="1"/>
+                  <path d="M8 1.7V4.3" opacity="0.88" transform="rotate(45 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.76" transform="rotate(90 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.64" transform="rotate(135 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.52" transform="rotate(180 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.4" transform="rotate(225 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.28" transform="rotate(270 8 8)"/>
+                  <path d="M8 1.7V4.3" opacity="0.16" transform="rotate(315 8 8)"/>
+                </g>
+              </svg>
+              {{ t.plan1StatusStarting }}
+            </span>
+            <!-- Once restic can divide bytes done by bytes to do, the bar and
+                 the number it stands for share a line, as they do in
+                 PlanStatusRow: a determinate bar that never says how far
+                 along it is leaves the reader guessing. -->
             <span class="kh-demo-running">
               <span class="kh-demo-progress"><span class="kh-demo-progress-fill"></span></span>
               <span class="kh-demo-pct"></span>

--- a/site/.vitepress/theme/components/MenuBarDemo.vue
+++ b/site/.vitepress/theme/components/MenuBarDemo.vue
@@ -8,10 +8,10 @@ import { useData, withBase } from 'vitepress'
 // recreation honest in every language.
 const defaults = {
   ariaLabel:
-    'Animated demo of the Keelhaven menu bar app running a backup: a plan named Documents is backed up to an external drive, showing only a small progress bar while running, then a Backup complete notification.',
+    'Animated demo of the Keelhaven menu bar app running a backup: a plan named Documents is backed up to an external drive, showing a small progress bar and its percentage while running, then a Backup complete notification.',
   clock: 'Mon 9:41 AM',
   plan1Name: 'Documents',
-  plan1Sched: 'Daily at 9:00 AM',
+  plan1Sched: 'Every day at 9:00 AM',
   plan1StatusIdle: 'Backed up 2 hours ago',
   plan1StatusDone: 'Backed up 1 second ago',
   plan2Name: 'Photos',
@@ -36,9 +36,9 @@ const t = computed(() => ({
   <!-- An animated recreation of the real menu bar popover, drawn from the
        SwiftUI sources (MenuBarView / PlanStatusRow) so it can't drift into
        showing UI the app doesn't have. Pure CSS, one ~12s loop: idle → the
-       cursor clicks Back Up Now → the quiet progress bar runs → done, with
-       the completion notification the app actually posts. All timing lives
-       in landing.css under .kh-demo-*. -->
+       cursor clicks Back Up Now → the progress bar and its percentage run →
+       done, with the completion notification the app actually posts. All
+       timing lives in landing.css under .kh-demo-*. -->
   <div class="kh-demo" role="img"
        :aria-label="t.ariaLabel">
 
@@ -83,7 +83,13 @@ const t = computed(() => ({
           <div class="kh-demo-statusline">
             <span class="kh-demo-status kh-demo-status-idle">{{ t.plan1StatusIdle }}</span>
             <span class="kh-demo-status kh-demo-status-done">{{ t.plan1StatusDone }}</span>
-            <span class="kh-demo-progress"><span class="kh-demo-progress-fill"></span></span>
+            <!-- The bar and the number it stands for share a line, as they
+                 do in PlanStatusRow: a determinate bar that never says how
+                 far along it is leaves the reader guessing. -->
+            <span class="kh-demo-running">
+              <span class="kh-demo-progress"><span class="kh-demo-progress-fill"></span></span>
+              <span class="kh-demo-pct"></span>
+            </span>
           </div>
         </div>
       </div>

--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -869,10 +869,15 @@ body:has(.kh-landing) .VPLocalNav {
    MenuBarDemo.vue — an animated recreation of the menu bar popover, kept
    faithful to Keelhaven/MenuBar/*.swift: Apple system colors for the status
    dot and progress bar, the percentage the app prints beside the bar, the
-   real strings. One 12s loop; every element animates on the same 12s clock
-   so the choreography reads as percentages of that loop:
-     0–20%  idle           21.5%  click Back Up Now
-     24–74% backup runs    76–91% done + notification
+   real strings. The running row is shown in both of the states the code can
+   produce, in the order it produces them: the spinner while restic has yet
+   to report anything (all a short incremental run ever shows), then the bar
+   and its percentage once there is a total to divide by. One 12s loop; every
+   element animates on the same 12s clock so the choreography reads as
+   percentages of that loop:
+     0–20%  idle              21.5%  click Back Up Now
+     24–32% engine starting   33–74% backup runs with a percentage
+     76–91% done + notification
      92–96% crossfade back to the idle frame for a clean loop seam.
    Colors here are macOS chrome, not brand tokens — the popover must look
    like the Mac app, not like the website. The frame around it stays brand. */
@@ -919,10 +924,6 @@ body:has(.kh-landing) .VPLocalNav {
 }
 .kh-landing .kh-demo-mb-idle { animation: kh-demo-mb-idle 12s infinite; }
 .kh-landing .kh-demo-mb-busy { opacity: 0; animation: kh-demo-mb-busy 12s infinite; }
-.kh-landing .kh-demo-mb-busy-spin {
-  transform-origin: 12px 12px;
-  animation: kh-demo-spin 1.4s linear infinite;
-}
 @keyframes kh-demo-mb-idle {
   0%, 22% { opacity: 1; }
   24%, 74% { opacity: 0; }
@@ -1068,7 +1069,34 @@ body:has(.kh-landing) .VPLocalNav {
   76%, 91% { opacity: 1; }
   95%, 100% { opacity: 0; }
 }
-/* The bar and its percentage are one line, as in PlanStatusRow: the row
+/* The first thing a run shows: a spinner and a caption, because restic has
+   reported nothing yet and a bar would have to sit at zero to pretend
+   otherwise. It holds for about a second here; in a short incremental run,
+   where restic finishes before it ever reports a total, it is the whole of
+   what the row shows. */
+.kh-landing .kh-demo-starting {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: rgba(60, 60, 67, 0.6);
+  opacity: 0;
+  animation: kh-demo-starting 12s infinite;
+}
+@keyframes kh-demo-starting {
+  0%, 23% { opacity: 0; }
+  24.5%, 31% { opacity: 1; }
+  32.5%, 100% { opacity: 0; }
+}
+.kh-landing .kh-demo-spinner { flex: none; }
+/* Eight spokes stepped round, not swept: the macOS spinner ticks. */
+.kh-landing .kh-demo-spinner-spokes {
+  transform-origin: 8px 8px;
+  animation: kh-demo-spin 0.9s steps(8) infinite;
+}
+
+/* Then the bar and its percentage, one line, as in PlanStatusRow: the row
    carries the number the bar stands for rather than leaving the bar to
    speak for itself. The line as a whole fades in and out; the bar and the
    number animate inside it. */
@@ -1082,8 +1110,8 @@ body:has(.kh-landing) .VPLocalNav {
   animation: kh-demo-progress 12s infinite;
 }
 @keyframes kh-demo-progress {
-  0%, 23% { opacity: 0; }
-  24.5%, 74% { opacity: 1; }
+  0%, 31.5% { opacity: 0; }
+  33%, 74% { opacity: 1; }
   75.5%, 100% { opacity: 0; }
 }
 .kh-landing .kh-demo-progress {
@@ -1104,12 +1132,12 @@ body:has(.kh-landing) .VPLocalNav {
 /* Uneven steps on purpose — real backups scan, stall on a big file, then
    sprint. A linear sweep reads as fake. */
 @keyframes kh-demo-fill {
-  0%, 24% { width: 0; }
-  30% { width: 21%; }
-  38% { width: 36%; }
-  46% { width: 41%; }
-  56% { width: 68%; }
-  64% { width: 87%; }
+  0%, 33% { width: 0; }
+  38% { width: 21%; }
+  44% { width: 36%; }
+  50% { width: 41%; }
+  58% { width: 68%; }
+  65% { width: 87%; }
   71% { width: 96%; }
   74%, 90% { width: 100%; }
   91%, 100% { width: 0; }
@@ -1139,12 +1167,12 @@ body:has(.kh-landing) .VPLocalNav {
   content: counter(kh-demo-pct) '%';
 }
 @keyframes kh-demo-pct {
-  0%, 24% { --kh-demo-pct: 0; }
-  30% { --kh-demo-pct: 21; }
-  38% { --kh-demo-pct: 36; }
-  46% { --kh-demo-pct: 41; }
-  56% { --kh-demo-pct: 68; }
-  64% { --kh-demo-pct: 87; }
+  0%, 33% { --kh-demo-pct: 0; }
+  38% { --kh-demo-pct: 21; }
+  44% { --kh-demo-pct: 36; }
+  50% { --kh-demo-pct: 41; }
+  58% { --kh-demo-pct: 68; }
+  65% { --kh-demo-pct: 87; }
   71% { --kh-demo-pct: 96; }
   74%, 90% { --kh-demo-pct: 100; }
   91%, 100% { --kh-demo-pct: 0; }

--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -868,9 +868,9 @@ body:has(.kh-landing) .VPLocalNav {
 /* ---------------------------------------------------------------- demo --
    MenuBarDemo.vue — an animated recreation of the menu bar popover, kept
    faithful to Keelhaven/MenuBar/*.swift: Apple system colors for the status
-   dot and progress bar, no percentage text while running (the app shows
-   none), the real strings. One 12s loop; every element animates on the same
-   12s clock so the choreography reads as percentages of that loop:
+   dot and progress bar, the percentage the app prints beside the bar, the
+   real strings. One 12s loop; every element animates on the same 12s clock
+   so the choreography reads as percentages of that loop:
      0–20%  idle           21.5%  click Back Up Now
      24–74% backup runs    76–91% done + notification
      92–96% crossfade back to the idle frame for a clean loop seam.
@@ -1068,15 +1068,16 @@ body:has(.kh-landing) .VPLocalNav {
   76%, 91% { opacity: 1; }
   95%, 100% { opacity: 0; }
 }
-.kh-landing .kh-demo-progress {
+/* The bar and its percentage are one line, as in PlanStatusRow: the row
+   carries the number the bar stands for rather than leaving the bar to
+   speak for itself. The line as a whole fades in and out; the bar and the
+   number animate inside it. */
+.kh-landing .kh-demo-running {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 6px;
-  height: 4px;
-  border-radius: 2px;
-  background: rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   opacity: 0;
   animation: kh-demo-progress 12s infinite;
 }
@@ -1084,6 +1085,13 @@ body:has(.kh-landing) .VPLocalNav {
   0%, 23% { opacity: 0; }
   24.5%, 74% { opacity: 1; }
   75.5%, 100% { opacity: 0; }
+}
+.kh-landing .kh-demo-progress {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.1);
+  overflow: hidden;
 }
 .kh-landing .kh-demo-progress-fill {
   display: block;
@@ -1105,6 +1113,41 @@ body:has(.kh-landing) .VPLocalNav {
   71% { width: 96%; }
   74%, 90% { width: 100%; }
   91%, 100% { width: 0; }
+}
+
+/* The number is driven by one custom property counted out through a CSS
+   counter, on the same keyframes as the fill above — so the digits and the
+   bar can't drift apart the way two hand-written timelines would. Registering
+   it lets the count run smoothly between steps; where @property is not
+   understood the property still animates, just stepping between them. */
+@property --kh-demo-pct {
+  syntax: '<integer>';
+  initial-value: 0;
+  inherits: false;
+}
+.kh-landing .kh-demo-pct {
+  font-size: 13px;
+  color: rgba(60, 60, 67, 0.6);
+  font-variant-numeric: tabular-nums;
+  animation: kh-demo-pct 12s infinite;
+  /* The counter is reset here rather than on ::after: the property is
+     registered as non-inheriting, so the pseudo-element would read the
+     initial 0 instead of whatever the animation currently holds. */
+  counter-reset: kh-demo-pct var(--kh-demo-pct);
+}
+.kh-landing .kh-demo-pct::after {
+  content: counter(kh-demo-pct) '%';
+}
+@keyframes kh-demo-pct {
+  0%, 24% { --kh-demo-pct: 0; }
+  30% { --kh-demo-pct: 21; }
+  38% { --kh-demo-pct: 36; }
+  46% { --kh-demo-pct: 41; }
+  56% { --kh-demo-pct: 68; }
+  64% { --kh-demo-pct: 87; }
+  71% { --kh-demo-pct: 96; }
+  74%, 90% { --kh-demo-pct: 100; }
+  91%, 100% { --kh-demo-pct: 0; }
 }
 
 /* --- footer rows -------------------------------------------------------- */

--- a/site/index.md
+++ b/site/index.md
@@ -86,7 +86,8 @@ const releases = computed(
 
 <!-- MenuBarDemo is an animated recreation of the popover, built from the
      SwiftUI sources rather than a screenshot, so it stays honest about what
-     the app shows — including the quiet no-numbers progress bar. -->
+     the app shows — down to the percentage that rides beside the progress
+     bar while a backup runs. -->
 <ShotFrame><MenuBarDemo /></ShotFrame>
 
 </LandingSection>

--- a/site/index.md
+++ b/site/index.md
@@ -86,8 +86,8 @@ const releases = computed(
 
 <!-- MenuBarDemo is an animated recreation of the popover, built from the
      SwiftUI sources rather than a screenshot, so it stays honest about what
-     the app shows — down to the percentage that rides beside the progress
-     bar while a backup runs. -->
+     the app shows — the spinner before the engine reports anything, then the
+     percentage that rides beside the progress bar. -->
 <ShotFrame><MenuBarDemo /></ShotFrame>
 
 </LandingSection>

--- a/site/zh/index.md
+++ b/site/zh/index.md
@@ -46,11 +46,12 @@ landing:
   # 演示动画的界面文案，取自 App 自带的简体中文本地化
   # （Keelhaven/Localizable.xcstrings），保证演示与真实应用一字不差。
   demo:
-    ariaLabel: Keelhaven 菜单栏应用执行备份的动画演示：名为「文稿」的计划备份到外置硬盘，运行时显示一个小小的进度条和它的百分比，然后弹出「备份完成」通知。
+    ariaLabel: Keelhaven 菜单栏应用执行备份的动画演示：名为「文稿」的计划备份到外置硬盘，运行时先转圈等待备份引擎，随后显示一个小小的进度条和它的百分比，然后弹出「备份完成」通知。
     clock: 周一 9:41
     plan1Name: 文稿
     plan1Sched: 每天 9:00
     plan1StatusIdle: 2 小时前完成备份
+    plan1StatusStarting: 正在备份…
     plan1StatusDone: 1 秒钟前完成备份
     plan2Name: 照片
     plan2Sched: 每小时
@@ -108,7 +109,8 @@ const releases = computed(
 <LandingSection id="tour" eyebrow="00 · 看一眼" title="一个菜单栏图标，就是整个应用。">
 
 <!-- MenuBarDemo 是弹窗界面的动画复刻，按 SwiftUI 源码绘制而非截图，
-     保证展示的和应用实际拥有的一致——包括备份进行时进度条旁边的那个百分比。 -->
+     保证展示的和应用实际拥有的一致——包括备份刚开始时的转圈，
+     以及 restic 报出总量之后进度条旁边的那个百分比。 -->
 <ShotFrame><MenuBarDemo /></ShotFrame>
 
 </LandingSection>

--- a/site/zh/index.md
+++ b/site/zh/index.md
@@ -46,7 +46,7 @@ landing:
   # 演示动画的界面文案，取自 App 自带的简体中文本地化
   # （Keelhaven/Localizable.xcstrings），保证演示与真实应用一字不差。
   demo:
-    ariaLabel: Keelhaven 菜单栏应用执行备份的动画演示：名为「文稿」的计划备份到外置硬盘，运行时只显示一个小小的进度条，然后弹出「备份完成」通知。
+    ariaLabel: Keelhaven 菜单栏应用执行备份的动画演示：名为「文稿」的计划备份到外置硬盘，运行时显示一个小小的进度条和它的百分比，然后弹出「备份完成」通知。
     clock: 周一 9:41
     plan1Name: 文稿
     plan1Sched: 每天 9:00
@@ -108,7 +108,7 @@ const releases = computed(
 <LandingSection id="tour" eyebrow="00 · 看一眼" title="一个菜单栏图标，就是整个应用。">
 
 <!-- MenuBarDemo 是弹窗界面的动画复刻，按 SwiftUI 源码绘制而非截图，
-     保证展示的和应用实际拥有的一致——包括那个安静的、不报数字的进度条。 -->
+     保证展示的和应用实际拥有的一致——包括备份进行时进度条旁边的那个百分比。 -->
 <ShotFrame><MenuBarDemo /></ShotFrame>
 
 </LandingSection>


### PR DESCRIPTION
The landing page's popover is an animated recreation of the real one rather
than a screenshot, which keeps it honest only for as long as someone updates
it. It had drifted in three ways before 0.8.0.

### What restic actually reports (measured, not assumed)

Against the pinned restic 0.19.1, `restic backup --json` writing to a pipe:

| run | duration | status lines |
|---|---|---|
| first backup, 400 MB | 1.5s | 7, from 15% up |
| same source again, nothing changed | 0.8s | **0** |
| same source, one byte changed | 0.9s | 1, at 97% |

restic reports about every 0.2s, but only once it has a total to divide by.
So both row states are real and which one you see is a matter of how much
there is to do:

- A **first backup, or any run with real data to copy**, gets a determinate
  bar — and since #60, the percentage beside it.
- A **short incremental run** — the common case for a plan that already
  exists — never leaves the indeterminate state `runBackup` sets before
  restic has said anything. It shows a spinner and "Backing up…" start to
  finish.

### The demo showed only the second half of that

It drew a bare determinate bar for the whole run. Now it plays both states in
the order the code produces them: spinner and caption for the first second,
then the bar with its percentage. Showing only the bar made the percentage
look like what a backup always looks like, which it isn't.

The percentage itself is one registered custom property (`--kh-demo-pct`)
rendered through a CSS counter and animated on **the fill's own keyframes** —
not a second timeline written by hand — so the digits and the bar cannot
disagree. Registering the property lets the count run smoothly between steps;
where `@property` isn't understood the property still animates and the number
steps instead. Everything stays pure CSS on the same 12s loop, so
`prefers-reduced-motion` still holds the calm idle frame.

### The menu bar glyph was spinning

The app swaps the Keelhaven mark for a static `arrow.triangle.2.circlepath`
while a run is active and never animates it. The demo rotated it, which is a
claim about the UI rather than a staging convention. It is still now; the
row's spinner is where the motion honestly belongs.

### One caption the app stopped printing

The demo said "Daily at 9:00 AM". `Schedule.displayText` has said "Every day
at 9:00 AM" since #60, so the frequency picker and the plan row agree. The zh
mirror needed no change — it translated the frequency ("每天 9:00") rather
than the old English sentence.

## Testing

- `npm --prefix site run build` — succeeds.
- restic behaviour measured directly with the pinned 0.19.1 binary (table
  above) before changing anything.
- Both locales driven frame by frame in Chrome with the animations paused.
  The states never overlap: idle through 2.8s, spinner 2.9–3.9s, bar 4.0–8.9s,
  done from 9.2s. The number tracks the bar at every sample — 1/1, 14/14,
  34/34, 69/69, 100/100 — and reads 0 while the row is idle or done.
- New string "Backing up…" is the app's own, and is mirrored in zh
  ("正在备份…") from `Localizable.xcstrings`.

## Not in this PR

0.8.0 also adds Preview Backup, the `--no-scan` variant of the running row
and "No changes — nothing new to back up" to the same row; all three are
states this demo never enters (one ordinary backup, and the ⋯ menu is never
opened). Separately, the landing copy still never says Keelhaven can restore
— every mention of restoring points at the restic CLI — and the retention FAQ
lists two presets where there are now four (#59). Both want their own pass
before the release.
