### PR TITLE
Two more voices, both from the Chinese posts

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -195,6 +195,16 @@ Nice scope — restic plus a menu bar UI is exactly the missing piece, and keepi
 No Dock icon, no main window. Pick the folders, the storage and the schedule, and it runs quietly in the background, speaking up only when something fails. The password is kept in the macOS Keychain, and it writes a standard restic repository, so you can restore from the restic command line without this app.
 
 </VoiceCard>
+<VoiceCard name="An_yhl" handle="@An_yhl" source="X" href="https://x.com/An_yhl/status/2096486139725070835" note="translated from Chinese">
+
+A backup tool in the menu bar really is less to think about. Worth a look if you already use restic.
+
+</VoiceCard>
+<VoiceCard name="小众软件" handle="@appinn" source="X" href="https://x.com/appinn/status/2096408933376065669" note="translated from Chinese">
+
+Keelhaven: a restic backup tool for the macOS menu bar. Free and open source.
+
+</VoiceCard>
 </div>
 
 </LandingSection>

--- a/site/zh/index.md
+++ b/site/zh/index.md
@@ -212,6 +212,16 @@ Beta 版还没做 Apple 公证，第一次打开要多点一次确认，[下面�
 无 Dock 图标，没有主窗口。选定文件夹、备份存储介质、定时策略，后台静默执行，出错才推送通知。密码仅保存在 macOS 钥匙串，生成标准 restic 仓库，脱离本软件也能用 restic 命令行恢复。
 
 </VoiceCard>
+<VoiceCard name="An_yhl" handle="@An_yhl" source="X" href="https://x.com/An_yhl/status/2096486139725070835">
+
+菜单栏备份工具确实省心，restic 用户可以试试
+
+</VoiceCard>
+<VoiceCard name="小众软件" handle="@appinn" source="X" href="https://x.com/appinn/status/2096408933376065669">
+
+Keelhaven：macOS 菜单栏的 restic 备份工具，免费开源
+
+</VoiceCard>
 <VoiceCard name="mao mao" handle="@maomao000211" source="X" href="https://x.com/maomao000211/status/2095382774874267938" note="译自英文">
 
 思路很对，restic 配上菜单栏界面，正好补上了缺的那一块。仓库保持标准格式，用户就不会被你的软件绑住。不要账号、不做遥测，光这一条就够说服不少人了。


### PR DESCRIPTION
Two posts you sent, added to the Voices section.

- **@An_yhl** — 「菜单栏备份工具确实省心，restic 用户可以试试」
- **小众软件 (@appinn)** — 「Keelhaven：macOS 菜单栏的 restic 备份工具，免费开源」

Both were written in Chinese, so the zh page quotes them verbatim and the
English page carries a translation with the `note` the card already exists
for — the original is one click away at `href` either way, which is the point
of linking testimonials rather than just printing them.

## Layout

Four cards land as 2×2 rather than orphaning one: the voices grid is
`auto-fit` at a 340px minimum and the section measures 1032px, which holds
two columns, so the fourth card starts a second row. Measured in the browser
rather than assumed — at three columns this would have been a 3+1.

Ordering keeps the rule the section already followed: quotes said in the
reader's own language first, translations after. So the English page reads
mao mao → 小弟调调 → An_yhl → 小众软件, and the zh page reads 小弟调调 →
An_yhl → 小众软件 → mao mao. Both new quotes are short, and on the English
page they pair off in the second row, so each row's cards come out the same
height.

## One thing to check

X returns 402 to any fetch, so I could not read the posts to confirm the
display names. `An_yhl` is what you told me to use. **小众软件** is their
known name for @appinn but I could not verify it against the profile — say
the word and I will change it.

## Testing

- `npm --prefix site run build` — succeeds.
- Both pages opened in Chrome: 2×2 grid, no orphan row, equal card heights
  per row, and every card's source link points at the post it quotes.
