### PR TITLE
Close out the SonarCloud findings on our scripts and workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# The workflows pin third-party actions to commit SHAs so a moved tag can't
+# swap the code under us. A pin without an updater is just a frozen version,
+# so Dependabot opens the bump PRs that keep those SHAs current.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # ResticS3IntegrationTests.swift.
       - name: Start MinIO (S3 integration tests)
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/minio" \
+          curl --proto "=https" -fsSL -o "$RUNNER_TEMP/minio" \
             "https://dl.min.io/server/minio/release/darwin-$(uname -m | sed 's/x86_64/amd64/')/minio"
           chmod +x "$RUNNER_TEMP/minio"
           MINIO_ROOT_USER=keelhaven-test MINIO_ROOT_PASSWORD=keelhaven-test-secret \
@@ -95,7 +95,7 @@ jobs:
         run: |
           REST_SERVER_VERSION=0.14.0
           ARCH=$(uname -m | sed 's/x86_64/amd64/')
-          curl -fsSL -o "$RUNNER_TEMP/rest-server.tar.gz" \
+          curl --proto "=https" -fsSL -o "$RUNNER_TEMP/rest-server.tar.gz" \
             "https://github.com/restic/rest-server/releases/download/v${REST_SERVER_VERSION}/rest-server_${REST_SERVER_VERSION}_darwin_${ARCH}.tar.gz"
           tar -xzf "$RUNNER_TEMP/rest-server.tar.gz" -C "$RUNNER_TEMP"
           REST_SERVER_BIN="$RUNNER_TEMP/rest-server_${REST_SERVER_VERSION}_darwin_${ARCH}/rest-server"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
       # the bump step left main on.
       - name: Publish GitHub Release
         if: env.PUBLISHING == 'true'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           target_commitish: ${{ steps.bump.outputs.sha || github.sha }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -85,10 +85,10 @@ jobs:
           printf '{"version": "%s", "dmgURL": "https://keelhaven.app/downloads/%s"}\n' "$VERSION" "$ASSET" > site/public/latest.json
       - name: Build site
         run: |
-          npm ci --prefix site
+          npm ci --ignore-scripts --prefix site
           npm run build --prefix site
       - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ update: ## Install the latest build of main from CI (builds on demand, no local 
 	./Scripts/install-latest.sh
 
 dev-site: ## Preview the website locally with live reload (http://localhost:5173/)
-	@[ -d site/node_modules ] || npm --prefix site install
+	@[ -d site/node_modules ] || npm --prefix site install --ignore-scripts
 	npm --prefix site run dev
 
 deploy-site: ## Build site/ and push it to keelhaven-site's gh-pages (manual deploy)

--- a/Scripts/bench-remote-ls.sh
+++ b/Scripts/bench-remote-ls.sh
@@ -86,7 +86,7 @@ start_minio() {
         local arch os
         arch="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
         os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-        curl -fsSL -o "$WORK/minio" "https://dl.min.io/server/minio/release/${os}-${arch}/minio"
+        curl --proto "=https" -fsSL -o "$WORK/minio" "https://dl.min.io/server/minio/release/${os}-${arch}/minio"
         chmod +x "$WORK/minio"
         minio_bin="$WORK/minio"
     fi

--- a/Scripts/deploy-site.sh
+++ b/Scripts/deploy-site.sh
@@ -41,7 +41,7 @@ else
   echo "No published release found (or gh isn't authenticated) — deploying without a DMG mirror."
 fi
 
-npm --prefix site ci
+npm --prefix site ci --ignore-scripts
 npm --prefix site run build
 
 dist="site/.vitepress/dist"

--- a/Scripts/fetch-restic.sh
+++ b/Scripts/fetch-restic.sh
@@ -52,7 +52,7 @@ rm -f restic restic-LICENSE.txt "$MARKER"
 for arch in $ARCHES; do
     file="restic_${VERSION}_darwin_${arch}.bz2"
     echo "Downloading ${file}..."
-    curl -fsSL -o "$file" \
+    curl --proto "=https" -fsSL -o "$file" \
         "https://github.com/restic/restic/releases/download/v${VERSION}/${file}"
     case "$arch" in
         amd64) expected="$SHA_AMD64" ;;
@@ -74,7 +74,7 @@ rm -f restic_${VERSION}_darwin_*
 
 # Copyright notice for the binary we just vendored (see header comment).
 echo "Downloading restic-LICENSE.txt..."
-curl -fsSL -o restic-LICENSE.txt \
+curl --proto "=https" -fsSL -o restic-LICENSE.txt \
     "https://raw.githubusercontent.com/restic/restic/v${VERSION}/LICENSE"
 # A silent CDN error page would be worse than a hard failure: the build would
 # happily ship a bundle whose "license" is HTML.

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -29,18 +29,20 @@ trap cleanup EXIT
 
 # The site mirrors each release's DMG next to a small manifest. Read the
 # manifest for the download URL; if the site is unreachable fall back to
-# the GitHub release the mirror was made from.
-DMG_URL=$(curl -fsSL "$MANIFEST" 2>/dev/null \
+# the GitHub release the mirror was made from. Every fetch pins the scheme
+# with --proto "=https", so a redirect can't quietly downgrade the transfer
+# to plain HTTP and hand the installer a rewritten DMG.
+DMG_URL=$(curl --proto "=https" -fsSL "$MANIFEST" 2>/dev/null \
     | sed -n 's/.*"dmgURL": *"\([^"]*\)".*/\1/p' || true)
 if [ -z "$DMG_URL" ]; then
-    DMG_URL=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    DMG_URL=$(curl --proto "=https" -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
         | sed -n 's/.*"browser_download_url": *"\([^"]*\.dmg\)".*/\1/p' | head -1) \
         || true
 fi
 [ -n "$DMG_URL" ] || fail "could not find the latest release. Download it from https://keelhaven.app instead."
 
 echo "Downloading ${DMG_URL##*/}..."
-curl -fL --progress-bar "$DMG_URL" -o "$TMP/Keelhaven.dmg"
+curl --proto "=https" -fL --progress-bar "$DMG_URL" -o "$TMP/Keelhaven.dmg"
 
 MOUNT=$(hdiutil attach "$TMP/Keelhaven.dmg" -nobrowse -readonly \
     | sed -n 's/.*\(\/Volumes\/.*\)/\1/p' | tail -1)


### PR DESCRIPTION
Works through the 13 open SonarCloud alerts in code scanning. Twelve are fixed here; the thirteenth is a false positive and is dismissed separately.

### `--proto "=https"` on every curl that follows redirects — 7 alerts
`shell:S6506`, `githubactions:S6506`. `-L` alone lets a redirect drop the transfer to plain HTTP, which for an installer or a vendored binary means someone on the wire can rewrite what we execute. Each of these now pins the scheme:

- `site/public/install.sh` — manifest, GitHub API fallback, and the DMG download (the third one wasn't flagged; it's the one that actually runs the download, so it got the same treatment)
- `Scripts/fetch-restic.sh` — the restic binary and its licence text
- `Scripts/bench-remote-ls.sh` and `.github/workflows/ci.yml` — MinIO and rest-server

Checked against the live endpoints, redirects and all: the GitHub release assets go through one cross-host https hop and `dl.min.io` through two, both still fine.

### `--ignore-scripts` on npm installs — 2 alerts
`shell:S6505`, `githubactions:S6505`. `Scripts/deploy-site.sh` and `website.yml` (plus `make dev-site` for consistency) no longer run dependency lifecycle scripts. esbuild is the one dependency in `site/` that ships a postinstall, so I ran `npm ci --ignore-scripts` on a copy of the site and built it — VitePress builds clean.

### Actions pinned to commit SHAs — 2 of 3 alerts
`githubactions:S7637`. `softprops/action-gh-release` → `efb3536` (v3.0.3), `peaceiris/actions-gh-pages` → `84c30a8` (v4.1.0). A pin with nothing to update it is just a frozen version, so `.github/dependabot.yml` is added to bump them monthly (it covers `actions/*` too).

**Left as-is:** `shenxianpeng/.github/.github/workflows/pr-labeler.yml@main` in `labeler.yml`. That's our own repo, and `@main` is deliberate — pinning it would mean every change to the shared labeler config needs a manual SHA bump here.

### Not a real finding — 1 alert
`githubactions:S7694` "Swift dependencies should be locked to verified versions" on `ci.yml`. `KeelhavenCore/Package.swift` declares no external dependencies at all, so there is no `Package.resolved` to lock. Dismissed as a false positive.