### PR TITLE
Give the shell scripts [[ ]], named parameters and a default case

### DIFF
--- a/Scripts/bench-remote-ls.sh
+++ b/Scripts/bench-remote-ls.sh
@@ -37,8 +37,9 @@ NO_CACHE="${BENCH_NO_CACHE:-0}"
 MINIO_PORT=9400
 SSHD_PORT=2400
 # Each RTT gets its own proxy: MinIO at 94xx, sshd at 24xx.
-proxy_port() { # backend, index
-    if [ "$1" = s3 ]; then echo $((9410 + $2)); else echo $((2410 + $2)); fi
+proxy_port() {
+    local backend="$1" index="$2"
+    if [[ "$backend" = "s3" ]]; then echo $((9410 + index)); else echo $((2410 + index)); fi
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -54,7 +55,7 @@ trap cleanup EXIT
 
 say() { printf '\033[1m%s\033[0m\n' "$*"; }
 now() { python3 -c 'import time; print(time.time())'; }
-elapsed() { python3 -c "print(f'{($2-$1):6.2f}')"; }
+elapsed() { local start="$1" end="$2"; python3 -c "print(f'{($end-$start):6.2f}')"; }
 
 command -v restic >/dev/null || { echo "restic not found — brew install restic" >&2; exit 1; }
 command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 1; }
@@ -110,9 +111,9 @@ start_sshd() {
     for candidate in /usr/libexec/sftp-server \
                      /usr/lib/openssh/sftp-server \
                      /usr/lib/ssh/sftp-server; do
-        [ -x "$candidate" ] && { sftp_server="$candidate"; break; }
+        [[ -x "$candidate" ]] && { sftp_server="$candidate"; break; }
     done
-    [ -n "$sftp_server" ] || { echo "no sftp-server binary found" >&2; exit 1; }
+    [[ -n "$sftp_server" ]] || { echo "no sftp-server binary found" >&2; exit 1; }
     mkdir -p "$d"; chmod 700 "$d"
     ssh-keygen -q -t ed25519 -f "$d/host_key" -N "" -C bench-host
     ssh-keygen -q -t ed25519 -f "$d/id_bench" -N "" -C bench-client
@@ -146,12 +147,12 @@ ssh_bench() { # port, then the remote command
     local port="$1"; shift
     ssh "${SSH_COMMON[@]}" -i "$WORK/sshd/id_bench" -p "$port" 127.0.0.1 "$@"
 }
-sftp_args() { echo "-p $1 -i $WORK/sshd/id_bench ${SSH_COMMON[*]}"; }
+sftp_args() { local port="$1"; echo "-p $port -i $WORK/sshd/id_bench ${SSH_COMMON[*]}"; }
 
 # restic invocation for a backend at a given port.
 restic_at() { # backend, port, then restic args
     local backend="$1" port="$2"; shift 2
-    if [ "$backend" = s3 ]; then
+    if [[ "$backend" = "s3" ]]; then
         AWS_ACCESS_KEY_ID=keelhaven-bench AWS_SECRET_ACCESS_KEY=keelhaven-bench-secret \
         RESTIC_PASSWORD=bench \
             restic -r "s3:http://127.0.0.1:$port/kh-bench/repo" "$@"
@@ -173,7 +174,7 @@ for backend in $BACKENDS; do
 done
 
 for backend in $BACKENDS; do
-    base_port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+    base_port=$([[ "$backend" = "s3" ]] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
     say "Seeding the $backend repository"
     restic_at "$backend" "$base_port" init >/dev/null 2>&1
     restic_at "$backend" "$base_port" backup "$WORK/src" --no-scan >/dev/null 2>&1
@@ -183,9 +184,9 @@ done
 # proxy's own overhead never hides in the baseline.
 index=0
 for rtt in $RTTS; do
-    [ "$rtt" = 0 ] && { index=$((index + 1)); continue; }
+    [[ "$rtt" = "0" ]] && { index=$((index + 1)); continue; }
     for backend in $BACKENDS; do
-        upstream=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+        upstream=$([[ "$backend" = "s3" ]] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
         python3 "$SCRIPT_DIR/netdelay.py" "$(proxy_port "$backend" "$index")" "$upstream" "$rtt" \
             >/dev/null 2>&1 &
         PIDS+=($!)
@@ -207,8 +208,8 @@ printf '%s\n' "--------------------------------------------------------------"
 for backend in $BACKENDS; do
     index=0
     for rtt in $RTTS; do
-        if [ "$rtt" = 0 ]; then
-            port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+        if [[ "$rtt" = "0" ]]; then
+            port=$([[ "$backend" = "s3" ]] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
         else
             port="$(proxy_port "$backend" "$index")"
         fi
@@ -237,7 +238,7 @@ for backend in $BACKENDS; do
     done
 done
 
-if [ "$NO_CACHE" = 1 ]; then
+if [[ "$NO_CACHE" = "1" ]]; then
     printf '\n'
     say "With restic's cache disabled (--no-cache)"
     printf '%-16s %10s\n' "backend · rtt" "full"
@@ -245,8 +246,8 @@ if [ "$NO_CACHE" = 1 ]; then
     for backend in $BACKENDS; do
         index=0
         for rtt in $RTTS; do
-            if [ "$rtt" = 0 ]; then
-                port=$([ "$backend" = s3 ] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
+            if [[ "$rtt" = "0" ]]; then
+                port=$([[ "$backend" = "s3" ]] && echo "$MINIO_PORT" || echo "$SSHD_PORT")
             else
                 port="$(proxy_port "$backend" "$index")"
             fi

--- a/Scripts/deploy-site.sh
+++ b/Scripts/deploy-site.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 branch=$(git branch --show-current)
-if [ "$branch" != "main" ]; then
+if [[ "$branch" != "main" ]]; then
   echo "⚠️  Deploying the working tree of '$branch', not main."
 fi
 
@@ -29,7 +29,7 @@ if info=$(gh release view --repo shenxianpeng/keelhaven --json tagName,assets \
     --jq '"\(.tagName)\t\([.assets[] | select(.name | endswith(".dmg"))][0].name // "")"' 2>/dev/null); then
   tag=${info%%$'\t'*}
   asset=${info#*$'\t'}
-  if [ -n "$asset" ]; then
+  if [[ -n "$asset" ]]; then
     echo "Mirroring $asset ($tag) into the deploy."
     gh release download "$tag" --repo shenxianpeng/keelhaven --pattern '*.dmg' --dir site/public/downloads --clobber
     printf '{"version": "%s", "dmgURL": "https://keelhaven.app/downloads/%s"}\n' \

--- a/Scripts/fetch-restic.sh
+++ b/Scripts/fetch-restic.sh
@@ -37,9 +37,9 @@ BINARY="$VENDOR_DIR/restic"
 LICENSE="$VENDOR_DIR/restic-LICENSE.txt"
 MARKER="$VENDOR_DIR/.variant"
 
-if [ -x "$BINARY" ] \
-    && [ -s "$LICENSE" ] \
-    && [ "$(cat "$MARKER" 2>/dev/null)" = "$VERSION-$MODE" ] \
+if [[ -x "$BINARY" ]] \
+    && [[ -s "$LICENSE" ]] \
+    && [[ "$(cat "$MARKER" 2>/dev/null)" = "$VERSION-$MODE" ]] \
     && "$BINARY" version 2>/dev/null | grep -q "restic $VERSION"; then
     echo "restic $VERSION ($MODE) already vendored at $BINARY"
     exit 0
@@ -57,12 +57,13 @@ for arch in $ARCHES; do
     case "$arch" in
         amd64) expected="$SHA_AMD64" ;;
         arm64) expected="$SHA_ARM64" ;;
+        *) echo "Unknown architecture: $arch" >&2; exit 1 ;;
     esac
     echo "$expected  $file" | shasum -a 256 -c
     bunzip2 -kf "$file"
 done
 
-if [ "$MODE" = "universal" ]; then
+if [[ "$MODE" = "universal" ]]; then
     lipo -create -output restic \
         "restic_${VERSION}_darwin_amd64" \
         "restic_${VERSION}_darwin_arm64"

--- a/Scripts/install-latest.sh
+++ b/Scripts/install-latest.sh
@@ -71,7 +71,7 @@ trigger_build() {
         sleep 3
         after=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 1 \
             --json databaseId --jq '.[0].databaseId // 0')
-        if [ "$after" != "$before" ]; then
+        if [[ "$after" != "$before" ]]; then
             gh run watch "$after" --repo "$REPO" --exit-status
             RUN="$after"
             return 0
@@ -82,32 +82,32 @@ trigger_build() {
 }
 
 RUN=""
-if [ "$MODE" != "force" ]; then
+if [[ "$MODE" != "force" ]]; then
     # `read` returns 1 at EOF, which under `set -e` would kill the script on
     # the perfectly normal "no artifact built yet" path.
     FOUND_RUN=""; FOUND_SHA=""
     read -r FOUND_RUN FOUND_SHA <<<"$(find_artifact)" || true
-    if [ -n "${FOUND_RUN:-}" ]; then
-        if [ "$MODE" = "reuse" ]; then
+    if [[ -n "${FOUND_RUN:-}" ]]; then
+        if [[ "$MODE" = "reuse" ]]; then
             RUN="$FOUND_RUN"
             echo "Using existing build from run $RUN (${FOUND_SHA:0:7})."
         else
             MAIN_SHA=$(gh api "repos/$REPO/commits/main" --jq .sha)
-            if [ "$FOUND_SHA" = "$MAIN_SHA" ]; then
+            if [[ "$FOUND_SHA" = "$MAIN_SHA" ]]; then
                 RUN="$FOUND_RUN"
                 echo "Existing build matches main (${MAIN_SHA:0:7}) — no rebuild needed."
             else
                 echo "Newest build is ${FOUND_SHA:0:7}, main is at ${MAIN_SHA:0:7}."
             fi
         fi
-    elif [ "$MODE" = "reuse" ]; then
+    elif [[ "$MODE" = "reuse" ]]; then
         echo "No $VARIANT artifact available to reuse (they expire after 14 days)." >&2
         echo "Run without --no-build to build one." >&2
         exit 1
     fi
 fi
 
-if [ -z "$RUN" ]; then
+if [[ -z "$RUN" ]]; then
     trigger_build
 fi
 
@@ -115,7 +115,7 @@ echo "Downloading the $VARIANT build from run $RUN..."
 gh run download "$RUN" --repo "$REPO" --pattern "Keelhaven-*-$VARIANT" --dir "$TMP"
 
 INNER=$(find "$TMP" -name 'Keelhaven.app.zip' | head -1)
-if [ -z "$INNER" ]; then
+if [[ -z "$INNER" ]]; then
     echo "Artifact did not contain Keelhaven.app.zip." >&2
     exit 1
 fi

--- a/Scripts/install-local.sh
+++ b/Scripts/install-local.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP="$REPO_ROOT/build/Build/Products/Release/Keelhaven.app"
 
-if [ ! -d "$APP" ]; then
+if [[ ! -d "$APP" ]]; then
     echo "No built app at $APP — run 'make build' first." >&2
     exit 1
 fi

--- a/Scripts/make-dmg.sh
+++ b/Scripts/make-dmg.sh
@@ -11,7 +11,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP="${1:-$REPO_ROOT/build/Build/Products/Release/Keelhaven.app}"
 OUT="${2:-$REPO_ROOT/Keelhaven.dmg}"
 
-if [ ! -d "$APP" ]; then
+if [[ ! -d "$APP" ]]; then
     echo "No app bundle at $APP — build one first (make build)." >&2
     exit 1
 fi

--- a/Scripts/release-local.sh
+++ b/Scripts/release-local.sh
@@ -34,7 +34,7 @@ if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
     exit 1
 fi
 branch=$(git branch --show-current)
-if [ "$branch" != "main" ]; then
+if [[ "$branch" != "main" ]]; then
     echo "⚠️  Releasing '$branch', not main."
 fi
 

--- a/Scripts/update-homebrew-tap.sh
+++ b/Scripts/update-homebrew-tap.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 VERSION="${1:-}"
 DMG="${2:-}"
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [ ! -f "$DMG" ]; then
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ ! -f "$DMG" ]]; then
     echo "Usage: update-homebrew-tap.sh <version> <dmg-path>" >&2
     exit 1
 fi
@@ -21,7 +21,7 @@ SHA256=$(shasum -a 256 "$DMG" | awk '{print $1}')
 
 # The token rides in the remote URL; GitHub Actions masks the secret in logs.
 REMOTE="https://github.com/shenxianpeng/homebrew-tap.git"
-if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then
+if [[ -n "${HOMEBREW_TAP_TOKEN:-}" ]]; then
     REMOTE="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/shenxianpeng/homebrew-tap.git"
 fi
 

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -17,12 +17,12 @@ MANIFEST="https://keelhaven.app/latest.json"
 
 fail() { echo "Error: $*" >&2; exit 1; }
 
-[ "$(uname -s)" = "Darwin" ] || fail "Keelhaven is a macOS app — this installer only runs on a Mac."
+[[ "$(uname -s)" = "Darwin" ]] || fail "Keelhaven is a macOS app — this installer only runs on a Mac."
 
 TMP=$(mktemp -d /tmp/keelhaven-install.XXXXXX)
 MOUNT=""
 cleanup() {
-    [ -n "$MOUNT" ] && hdiutil detach "$MOUNT" -quiet 2>/dev/null
+    [[ -n "$MOUNT" ]] && hdiutil detach "$MOUNT" -quiet 2>/dev/null
     rm -rf "$TMP"
 }
 trap cleanup EXIT
@@ -34,19 +34,19 @@ trap cleanup EXIT
 # to plain HTTP and hand the installer a rewritten DMG.
 DMG_URL=$(curl --proto "=https" -fsSL "$MANIFEST" 2>/dev/null \
     | sed -n 's/.*"dmgURL": *"\([^"]*\)".*/\1/p' || true)
-if [ -z "$DMG_URL" ]; then
+if [[ -z "$DMG_URL" ]]; then
     DMG_URL=$(curl --proto "=https" -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
         | sed -n 's/.*"browser_download_url": *"\([^"]*\.dmg\)".*/\1/p' | head -1) \
         || true
 fi
-[ -n "$DMG_URL" ] || fail "could not find the latest release. Download it from https://keelhaven.app instead."
+[[ -n "$DMG_URL" ]] || fail "could not find the latest release. Download it from https://keelhaven.app instead."
 
 echo "Downloading ${DMG_URL##*/}..."
 curl --proto "=https" -fL --progress-bar "$DMG_URL" -o "$TMP/Keelhaven.dmg"
 
 MOUNT=$(hdiutil attach "$TMP/Keelhaven.dmg" -nobrowse -readonly \
     | sed -n 's/.*\(\/Volumes\/.*\)/\1/p' | tail -1)
-[ -n "$MOUNT" ] && [ -d "$MOUNT/Keelhaven.app" ] || fail "the DMG did not contain Keelhaven.app."
+[[ -n "$MOUNT" ]] && [[ -d "$MOUNT/Keelhaven.app" ]] || fail "the DMG did not contain Keelhaven.app."
 
 echo "Installing to /Applications..."
 # A running menu-bar app would keep files busy while we replace them.


### PR DESCRIPTION
First of three passes over the 173 open SonarCloud issues. This one takes all 44 shell findings; the Swift and JS/Python ones follow separately.

## What changed

**`[` → `[[` (37 findings, rated high/reliability).** Every one of the nine scripts is already `#!/bin/bash`, so there is no portability argument for keeping `[`. Bare right-hand operands gained quotes on the way — inside `[[ ]]` an unquoted `s3` or `0` is a *glob pattern*, not a literal. None of these were meant as patterns, and `[[ "$backend" = s3 ]]` would have kept working by accident rather than by intent.

**Positional parameters to locals (6).** `proxy_port`, `elapsed` and `sftp_args` each carried a trailing comment naming their arguments (`# backend, index`). The names now live in the code instead, which is what `ssh_bench` and `restic_at` a few lines further down were already doing.

**A missing default case (1) — the only one with real teeth.** In `fetch-restic.sh`, the per-arch checksum lookup had no `*)` branch:

```bash
case "$arch" in
    amd64) expected="$SHA_AMD64" ;;
    arm64) expected="$SHA_ARM64" ;;
esac
echo "$expected  $file" | shasum -a 256 -c
```

An unrecognised arch falls through leaving `expected` holding the **previous loop iteration's** value, and the freshly downloaded binary gets verified against the wrong hash. Only reachable if `ARCHES` ever gains a value the case doesn't know — but failing loudly is the entire job of that block, and it was the one thing in this batch that could actually hurt.

## Verification

- `bash -n` and `shellcheck -S warning` clean on all nine scripts.
- `proxy_port`, `elapsed` and `sftp_args` extracted from both the old and new versions and run side by side — identical output across every input tried, including the float arithmetic in `elapsed`.
- The new `*)` branch exercised directly: `amd64` and `arm64` resolve as before, `mips` exits 1.
- `fetch-restic.sh` re-vendored restic **for real** — deleted the marker, ran the download + checksum + `lipo` path end to end, got back a universal binary (x86_64 + arm64), the BSD-2-Clause licence text and a correct `.variant`. Unknown modes are still rejected.
- The `[[ ! -d ]]` guards in `make-dmg.sh` and `install-local.sh` still fire on a missing app bundle.

## Still open, in the next two PRs

- **17 Swift findings** — unused parameters in protocol conformances (`makeNSView(context:)` and friends, which want `context _:` rather than deletion), empty blocks in tests, three empty closures needing a comment, one single-case `switch`, one triple-nested closure.
- **7 JS/Python findings** — two genuinely unused imports in `design/build.mjs`, three nested template literals, one `replace` → `replaceAll`, one over-complex function in `Scripts/netdelay.py`.

## What I do not plan to change

**104 of the 173 look like noise rather than debt**, and I would rather configure them away than churn the code:

- **`swift:S1075` (101) — "hardcoded URI".** 83 sit in `KeelhavenCore/Tests/`, where the whole point is asserting the exact restic command line; a test that read its paths from a parameter would be testing nothing. The rest are endpoint placeholders in the wizard UI.
- **`swift:S107` (3) — too many parameters.** `BackupPlan.init` takes 15 because the model has 15 fields. Wrapping them in a parameter object to satisfy a counter would make the call sites worse.

Both would need a `sonar-project.properties` (the project has none — it runs on Automatic Analysis) or dismissal in the SonarCloud UI. Say which you'd prefer and I'll do that as the last pass.