### PR TITLE
Close out the SonarCloud findings on the Swift code

### DIFF
--- a/Keelhaven/MenuBar/MenuBarView.swift
+++ b/Keelhaven/MenuBar/MenuBarView.swift
@@ -186,7 +186,7 @@ struct MenuBarView: View {
 /// stuck visible instead of fading (#71 follow-up). Reaching into the real
 /// NSScrollView and disabling its scroller is the only fix that sticks.
 private struct ScrollerSuppressor: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
+    func makeNSView(context _: Context) -> NSView {
         let probe = NSView(frame: .zero)
         DispatchQueue.main.async {
             var view: NSView? = probe
@@ -198,5 +198,8 @@ private struct ScrollerSuppressor: NSViewRepresentable {
         return probe
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ _: NSView, context _: Context) {
+        // Nothing to update: the suppressor disables the scroller once, at
+        // creation, and SwiftUI has no state to sync back afterwards.
+    }
 }

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -323,12 +323,11 @@ struct PlanStatusRow: View {
 
     @ViewBuilder
     private var trailingControl: some View {
-        switch runState {
-        case .running:
+        if case .running = runState {
             // The linear progress bar below already says "running" —
             // a second spinner up here is noise.
             EmptyView()
-        default:
+        } else {
             Button("Back Up Now") {
                 appState.runBackup(plan)
             }

--- a/Keelhaven/Support/AppDelegate.swift
+++ b/Keelhaven/Support/AppDelegate.swift
@@ -4,7 +4,7 @@ import AppKit
 /// already running. The delegate can't see AppState or open SwiftUI windows,
 /// so it forwards the event; MenuBarLabelView decides what to show.
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    func applicationDidFinishLaunching(_ _: Notification) {
         // About and Welcome read NSApp.applicationIconImage, which resolves
         // through the system icon cache — and this bundle shipped many builds
         // *without* an icon, so the cache serves the generic one even though
@@ -16,8 +16,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(
-        _ sender: NSApplication,
-        hasVisibleWindows flag: Bool
+        _ _: NSApplication,
+        hasVisibleWindows _: Bool
     ) -> Bool {
         NotificationCenter.default.post(name: .keelhavenReopen, object: nil)
         return false

--- a/Keelhaven/Support/ScheduleUI.swift
+++ b/Keelhaven/Support/ScheduleUI.swift
@@ -101,7 +101,10 @@ struct ScheduleEditor: View {
         // whatever is on screen reads as one sentence with the frequency it
         // belongs to.
         VStack(alignment: .leading, spacing: 8) {
-            frequencyRow(.hourly) {}
+            frequencyRow(.hourly) {
+                // Hourly schedules need nothing more than the radio itself —
+                // no time-of-day or weekday controls qualify it.
+            }
             frequencyRow(.daily) {
                 timePicker
             }

--- a/KeelhavenCore/Sources/KeelhavenCore/Keychain/InMemoryKeychain.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Keychain/InMemoryKeychain.swift
@@ -5,7 +5,10 @@ public final class InMemoryKeychain: KeychainStoring, @unchecked Sendable {
     private let lock = NSLock()
     private var storage: [String: String] = [:]
 
-    public init() {}
+    public init() {
+        // All state lives in the lock-protected storage dictionary, which
+        // starts empty — nothing else to set up.
+    }
 
     public func setSecret(_ secret: String, account: String) throws {
         lock.lock()

--- a/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticRunner.swift
+++ b/KeelhavenCore/Sources/KeelhavenCore/Restic/ResticRunner.swift
@@ -25,7 +25,7 @@ public actor ResticRunner {
             throw ResticError.classify(exitCode: result.exitCode, stderr: result.stderrText)
         }
         do {
-            return try ResticJSON.decoder.decode(Output.self, from: result.stdout)
+            return try ResticJSON.decoder.decode(type, from: result.stdout)
         } catch {
             throw ResticError.outputDecodingFailed(message: String(describing: error))
         }
@@ -98,12 +98,7 @@ public actor ResticRunner {
 
             // Install the termination bridge before launching so an early exit
             // can never be missed.
-            let exitCodes = AsyncStream<Int32> { exitContinuation in
-                process.terminationHandler = { finished in
-                    exitContinuation.yield(finished.terminationStatus)
-                    exitContinuation.finish()
-                }
-            }
+            let exitCodes = Self.exitCodeStream(for: process)
 
             let worker = Task {
                 do {
@@ -174,12 +169,7 @@ public actor ResticRunner {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        let exitCodes = AsyncStream<Int32> { exitContinuation in
-            process.terminationHandler = { finished in
-                exitContinuation.yield(finished.terminationStatus)
-                exitContinuation.finish()
-            }
-        }
+        let exitCodes = Self.exitCodeStream(for: process)
 
         do {
             try process.run()
@@ -198,6 +188,18 @@ public actor ResticRunner {
         }
 
         return ExecutionResult(exitCode: exitCode, stdout: await stdoutData, stderr: await stderrData)
+    }
+
+    /// Bridges `Process`'s termination handler into an `AsyncStream` so the
+    /// exit status can be awaited alongside output collection. Must be
+    /// installed before `run()` so an early exit is never missed.
+    private static func exitCodeStream(for process: Process) -> AsyncStream<Int32> {
+        AsyncStream { continuation in
+            process.terminationHandler = { finished in
+                continuation.yield(finished.terminationStatus)
+                continuation.finish()
+            }
+        }
     }
 
     private static func collect(_ handle: FileHandle) async -> Data {


### PR DESCRIPTION
## What

Closes **12 open SonarCloud findings** on the app + KeelhavenCore Swift code. All changes are behavior-neutral refactors:

| Rule | Where | Fix |
|---|---|---|
| `swift:S1172` ×7 (unused parameters) | `MenuBarView`, `AppDelegate`, `ResticRunner.run` | Protocol/API-required parameters now use anonymous local names (`_` / `context _`); external labels unchanged, so no call-site churn |
| `swift:S1186` ×3 (empty functions/closures) | `updateNSView`, `InMemoryKeychain.init`, hourly `frequencyRow` | Added comments explaining each intentional no-op |
| `swift:S1301` ×1 | `PlanStatusRow.trailingControl` | Two-arm `switch` → `if case .running`, same branches |
| `swift:S3087` ×1 | `ResticRunner` | Duplicated exit-code bridge (`AsyncStream` + `terminationHandler`) extracted into `exitCodeStream(for:)`, used by both run paths; closure nesting back at the limit |

Also, `run(...)` now decodes through its `decoding type` parameter instead of redundantly restating `Output.self`.

## Verification

- `swift test --package-path KeelhavenCore`: **169 tests, 0 failures** (same as baseline)
- Line coverage unchanged: `ResticRunner` and `InMemoryKeychain` stay at **100%**; the only uncovered line is the pre-existing `Destination.swift` one that CI's S3 suite covers
- `xcodebuild -scheme Keelhaven` Debug build succeeds

Refactors only — no behavior, API surface, or generated files touched.
