### PR TITLE
Close out the SonarCloud findings on the design scripts

### DIFF
--- a/Scripts/netdelay.py
+++ b/Scripts/netdelay.py
@@ -28,29 +28,30 @@ LISTEN, UPSTREAM, RTT_MS = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3]
 ONE_WAY = RTT_MS / 2000.0  # seconds, half the round trip per direction
 
 
+def _sender(q, dst):
+    """Hold loop: deliver queued chunks at their deadline, then half-close."""
+    while True:
+        item = q.get()
+        if item is None:
+            break
+        deadline, data = item
+        gap = deadline - time.time()
+        if gap > 0:
+            time.sleep(gap)
+        try:
+            dst.sendall(data)
+        except OSError:
+            break
+    try:
+        dst.shutdown(socket.SHUT_WR)
+    except OSError:
+        pass
+
+
 def pump(src, dst):
     """Forward src → dst, holding each chunk for one-way delay."""
     q = queue.Queue()
-
-    def sender():
-        while True:
-            item = q.get()
-            if item is None:
-                break
-            deadline, data = item
-            gap = deadline - time.time()
-            if gap > 0:
-                time.sleep(gap)
-            try:
-                dst.sendall(data)
-            except OSError:
-                break
-        try:
-            dst.shutdown(socket.SHUT_WR)
-        except OSError:
-            pass
-
-    thread = threading.Thread(target=sender, daemon=True)
+    thread = threading.Thread(target=_sender, args=(q, dst), daemon=True)
     thread.start()
     try:
         while True:

--- a/design/build.mjs
+++ b/design/build.mjs
@@ -19,7 +19,7 @@ import sharp from 'sharp'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { appIcon, mark, menuBarGlyph, monoMark, SILHOUETTE, RAYS, C } from './icon.mjs'
+import { appIcon, mark, menuBarGlyph, monoMark, C } from './icon.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SVG_DIR = join(ROOT, 'design/svg')
@@ -78,10 +78,10 @@ console.log(`· AppIcon.appiconset — ${images.length} sizes`)
 // ---------------------------------------------------------------------------
 // 3. Menu-bar template image (black + alpha; macOS recolours it per theme)
 // ---------------------------------------------------------------------------
-const glyphBlack = menuBarGlyph().replace(/currentColor/g, '#000000')
+const glyphBlack = menuBarGlyph().replaceAll('currentColor', '#000000')
 const menuImages = []
 for (const [scale, px] of [['1x', 18], ['2x', 36], ['3x', 54]]) {
-  const file = `menubar${scale === '1x' ? '' : `@${scale}`}.png`
+  const file = `menubar${scale === '1x' ? '' : '@' + scale}.png`
   await png(glyphBlack, px, join(MENUSET, file))
   menuImages.push({ idiom: 'mac', filename: file, scale })
 }

--- a/design/icon.mjs
+++ b/design/icon.mjs
@@ -191,12 +191,9 @@ export function light(lamp, { detail = true, spread = 190, reach = 62 } = {}) {
 export function water(horizon, lamp, { detail = true } = {}) {
   const y = horizon
   const edge = `M -8,${y} C 180,${y - 12} 348,${y + 9} 512,${y + 6} C 690,${y + 3} 852,${y - 14} 1032,${y + 1}`
-  return `
-  <path d="${edge} L 1032,1032 L -8,1032 Z" fill="url(#kh-water)"/>
-  <path d="${edge}" stroke="${C.foam}" stroke-width="4" opacity="0.22" fill="none"/>
-  <path d="M ${lamp.x - 36},${y} L ${lamp.x - 74},1032 L ${lamp.x + 74},1032 L ${lamp.x + 36},${y} Z"
-        fill="url(#kh-reflect)" ${detail ? 'filter="url(#kh-soft-sm)"' : ''} opacity="0.8"/>
-  ${detail ? `
+  // The fine highlight passes below the horizon turn to noise at 16–64 px,
+  // so `detail:false` drops them — the same rule as the app icon sizes.
+  const detailStrokes = detail ? `
   <g stroke="${C.beam}" stroke-linecap="round" opacity="0.55">
     <path d="M ${lamp.x - 52},${y + 46} h 104" stroke-width="11"/>
     <path d="M ${lamp.x - 36},${y + 96} h 72" stroke-width="10"/>
@@ -204,7 +201,13 @@ export function water(horizon, lamp, { detail = true } = {}) {
   </g>
   <g stroke="${C.foam}" stroke-width="11" stroke-linecap="round" opacity="0.15">
     <path d="M 178,${y + 62} h 104"/><path d="M 742,${y + 112} h 126"/><path d="M 246,${y + 166} h 80"/>
-  </g>` : ''}`
+  </g>` : ''
+  return `
+  <path d="${edge} L 1032,1032 L -8,1032 Z" fill="url(#kh-water)"/>
+  <path d="${edge}" stroke="${C.foam}" stroke-width="4" opacity="0.22" fill="none"/>
+  <path d="M ${lamp.x - 36},${y} L ${lamp.x - 74},1032 L ${lamp.x + 74},1032 L ${lamp.x + 36},${y} Z"
+        fill="url(#kh-reflect)" ${detail ? 'filter="url(#kh-soft-sm)"' : ''} opacity="0.8"/>
+  ${detailStrokes}`
 }
 
 /** Complete app icon. `detail:false` drops fine passes for 16–64 px art. */

--- a/design/materials.mjs
+++ b/design/materials.mjs
@@ -96,6 +96,9 @@ const CHIPS = [
 /** One card layout. Sizes are given outright — a single scale factor made the
  *  headline outrun the canvas on the taller cards. */
 function card({ w, h, icon, title, tag, chip, chips = CHIPS }) {
+  const chipList = chips.length
+    ? `<div class="chips">${chips.map(c => '<div class="chip">' + c + '</div>').join('')}</div>`
+    : ''
   return `<!doctype html><html><head><meta charset="utf-8"><style>${css}
   .stage { width: ${w}px; height: ${h}px; }
   .inner { padding: 0 ${Math.round(w * 0.06)}px; }
@@ -109,7 +112,7 @@ function card({ w, h, icon, title, tag, chip, chips = CHIPS }) {
     <img class="icon" src="data:image/png;base64,${iconData}">
     <h1>Keelhaven</h1>
     <p class="tag">${TAGLINE}</p>
-    ${chips.length ? `<div class="chips">${chips.map(c => `<div class="chip">${c}</div>`).join('')}</div>` : ''}
+    ${chipList}
   </div></div></body></html>`
 }
 


### PR DESCRIPTION
## What

Closes **7 open SonarCloud findings** on the design scripts, following up on #67 (scripts & workflows) and #70 (Swift code). All behavior-neutral:

| Rule | Where | Fix |
|---|---|---|
| `javascript:S1128` ×2 (unused imports) | `design/build.mjs` | Dropped the unused `RAYS` / `SILHOUETTE` imports |
| `javascript:S7781` ×1 | `design/build.mjs` | `replace(/currentColor/g, …)` → `replaceAll('currentColor', …)` |
| `javascript:S4624` ×3 (nested template literals) | `build.mjs`, `icon.mjs`, `materials.mjs` | Nested template content hoisted into plain constants (`'@' + scale`, `detailStrokes`, `chipList`) — output strings byte-identical |
| `python:S3776` ×1 (cognitive complexity 17 → ≤8) | `Scripts/netdelay.py` | Nested `sender` closure split into a module-level `_sender(q, dst)` helper with identical threading/shutdown semantics |

## Verification

- `node build.mjs` regenerated every committed asset (SVG masters, app icon set, menu-bar images, .icns, favicons) with **zero diff** — output is byte-identical
- Chip-markup equivalence asserted for both the empty and populated cases in `materials.mjs`
- `netdelay.py` smoke-tested through a live TCP echo: RTT 412 ms against the configured 400 ms, payload intact
- Note: `materials.mjs` needs Chromium to render PNGs; running it locally produces pixel diffs from the committed cards with **or without** this change (local Chrome ≠ the build-time Chrome), so those renders were not committed — this PR changes no generated files

Refactors only — no output, CLI surface, or behavior changes.
