### PR TITLE
Add Duplicate Plan to copy a plan to a new destination (#62)

### DIFF
--- a/Keelhaven/AppState.swift
+++ b/Keelhaven/AppState.swift
@@ -608,6 +608,10 @@ final class AppState {
     /// Which plan the Edit Plan window is editing — same handoff as restore.
     var editPlanID: UUID?
 
+    /// The plan a Duplicate window copies, set by the plan's Duplicate Plan…
+    /// action before opening it — same handoff as editPlanID (issue #62).
+    var duplicatePlanID: UUID?
+
     func restoreCredentials(for plan: BackupPlan) throws -> RepoCredentials {
         try credentials(for: plan)
     }

--- a/Keelhaven/EditPlan/EditPlanWindowView.swift
+++ b/Keelhaven/EditPlan/EditPlanWindowView.swift
@@ -159,7 +159,7 @@ struct EditPlanWindowView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Text("The destination can't be changed. To back up somewhere else, create a new backup plan.")
+            Text("The destination can't be changed. To back up somewhere else, choose Duplicate Plan… from the plan's action menu — everything else carries over.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Keelhaven/KeelhavenApp.swift
+++ b/Keelhaven/KeelhavenApp.swift
@@ -3,6 +3,7 @@ import KeelhavenCore
 
 enum WindowID {
     static let wizard = "wizard"
+    static let duplicatePlan = "duplicatePlan"
     static let about = "about"
     static let restore = "restore"
     static let welcome = "welcome"
@@ -33,6 +34,16 @@ struct KeelhavenApp: App {
 
         Window("New Backup Plan", id: WindowID.wizard) {
             WizardWindowView()
+                .environment(appState)
+        }
+        .windowResizability(.contentSize)
+
+        // The same wizard, prefilled from an existing plan: duplicating is
+        // "same plan, new destination", and the destination step already
+        // owns every destination form, its conflict rules and the adopt flow
+        // (issue #62). Seeded from `appState.duplicatePlanID`.
+        Window("Duplicate Backup Plan", id: WindowID.duplicatePlan) {
+            WizardWindowView(isDuplicate: true)
                 .environment(appState)
         }
         .windowResizability(.contentSize)

--- a/Keelhaven/Localizable.xcstrings
+++ b/Keelhaven/Localizable.xcstrings
@@ -2240,16 +2240,6 @@
         }
       }
     },
-    "The destination can't be changed. To back up somewhere else, create a new backup plan.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "备份目的地无法更改。若要备份到其他位置，请新建一个备份计划。"
-          }
-        }
-      }
-    },
     "The destination can't be inside a folder you're backing up.": {
       "localizations": {
         "zh-Hans": {
@@ -2701,6 +2691,46 @@
     },
     "⌘Q": {
       "shouldTranslate": false
+    },
+    "Duplicate Plan…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制计划…"
+          }
+        }
+      }
+    },
+    "Duplicate Backup Plan": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制备份计划"
+          }
+        }
+      }
+    },
+    "%@ copy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 副本"
+          }
+        }
+      }
+    },
+    "The destination can't be changed. To back up somewhere else, choose Duplicate Plan… from the plan's action menu — everything else carries over.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份目的地无法更改。如需备份到其他位置，请从该计划的操作菜单中选择“复制计划…”，其余设置都会一并带过去。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Keelhaven/MenuBar/PlanStatusRow.swift
+++ b/Keelhaven/MenuBar/PlanStatusRow.swift
@@ -171,6 +171,16 @@ struct PlanStatusRow: View {
             openWindow(id: WindowID.editPlan)
             NSApp.activate(ignoringOtherApps: true)
         }
+        // New plan with this one's folders, schedule, excludes, retention and
+        // verification — only the destination (and password) need deciding
+        // (issue #62). Opening the seeded wizard window beats inventing a
+        // destination form here: the wizard already owns every destination
+        // type, its conflict rules and the connect-to-existing flow.
+        Button("Duplicate Plan…") {
+            appState.duplicatePlanID = plan.id
+            openWindow(id: WindowID.duplicatePlan)
+            NSApp.activate(ignoringOtherApps: true)
+        }
         Button("Rename…") {
             promptRename()
         }

--- a/Keelhaven/Wizard/WizardModel.swift
+++ b/Keelhaven/Wizard/WizardModel.swift
@@ -419,4 +419,61 @@ final class WizardModel {
         creationError = fresh.creationError
         lastAutofilledName = fresh.lastAutofilledName
     }
+
+    // MARK: - Duplicating a plan (issue #62)
+
+    /// The name a duplicated plan starts with — Finder-style, so two rows can
+    /// never be indistinguishable: "Documents copy". Editable on the When
+    /// step's summary like any plan name.
+    static func duplicateName(of name: String) -> String {
+        String(localized: "\(name) copy")
+    }
+
+    /// Seeds this draft from an existing plan for the Duplicate window — every
+    /// non-secret setting: name, folders, schedule, verification, retention,
+    /// excludes and the advanced knobs. What is deliberately left behind:
+    ///
+    /// - Secrets. Repository passwords and S3/REST secrets are Keychain
+    ///   entries keyed by plan UUID, and a duplicate is a new plan with a new
+    ///   UUID — the wizard collects a fresh password (or adopts the existing
+    ///   repository's) exactly as it does for a plan created from scratch.
+    /// - Run history and the "first backup" anchor. Those belong to the
+    ///   source plan's past; the duplicate starts as any new plan does, with
+    ///   the first-backup-now checkbox at its default.
+    ///
+    /// The destination is copied as-is so the duplicate window shows what the
+    /// source has — the unchanged location trips the destination step's own
+    /// "already used" conflict, which is what tells the user to change it or
+    /// connect to the existing repository (the two things a duplicate is for).
+    func loadForDuplicate(from plan: BackupPlan) {
+        reset()
+        name = Self.duplicateName(of: plan.name)
+        sourcePaths = plan.sourcePaths
+        let components = plan.schedule.editorComponents
+        scheduleKind = components.kind
+        dailyTime = components.dailyTime
+        weekday = components.weekday
+        options.load(from: plan)
+        switch plan.destination {
+        case .local(let path):
+            destinationType = .local
+            localPath = path
+        case .s3(let config):
+            destinationType = .s3
+            s3Endpoint = config.endpoint
+            s3Bucket = config.bucket
+            s3Prefix = config.pathPrefix
+            s3AccessKey = config.accessKeyID
+        case .sftp(let config):
+            destinationType = .sftp
+            sftpUser = config.user
+            sftpHost = config.host
+            sftpPort = String(config.port)
+            sftpPath = config.path
+        case .rest(let config):
+            destinationType = .rest
+            restURL = config.url
+            restUsername = config.username
+        }
+    }
 }

--- a/Keelhaven/Wizard/WizardWindowView.swift
+++ b/Keelhaven/Wizard/WizardWindowView.swift
@@ -1,10 +1,23 @@
 import SwiftUI
 import KeelhavenCore
 
+/// The three-step flow for creating a plan. Serves both windows that create
+/// one: the New Backup Plan window from an empty draft, and the Duplicate
+/// Backup Plan window seeded from an existing plan (issue #62). Same steps,
+/// same destination forms and conflict rules — only the starting draft
+/// differs, so one view drives both.
 struct WizardWindowView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
     @State private var model = WizardModel()
+
+    /// True in the Duplicate Backup Plan window: the model is seeded from the
+    /// plan named by `appState.duplicatePlanID` instead of starting blank.
+    let isDuplicate: Bool
+
+    init(isDuplicate: Bool = false) {
+        self.isDuplicate = isDuplicate
+    }
 
     private let stepTitles = [
         String(localized: "What to back up"),
@@ -36,6 +49,19 @@ struct WizardWindowView: View {
         .frame(width: 560, height: 560)
         .onAppear {
             model.existingRepositoryLocations = appState.plans.map { $0.destination.repositoryLocation }
+        }
+        // Seeds the duplicate from its source plan. `.task(id:)`, not
+        // `onAppear`: it also re-seeds when the user picks another plan's
+        // Duplicate Plan… while this window stays open — the same handoff the
+        // Edit Plan window uses for `editPlanID`. Runs on first appearance
+        // regardless of the id, so a reopened window re-seeds even when
+        // `duplicatePlanID` did not change.
+        .task(id: appState.duplicatePlanID) {
+            guard isDuplicate,
+                  let id = appState.duplicatePlanID,
+                  let plan = appState.plans.first(where: { $0.id == id })
+            else { return }
+            model.loadForDuplicate(from: plan)
         }
     }
 


### PR DESCRIPTION
Closes #62.

## What & why

The Edit Plan window locks the destination ("To back up somewhere else, create a new backup plan") — so setting up a second destination for the same folders meant re-entering every setting by hand. This adds **Duplicate Plan…** to a plan's action menu (⋯ button and right-click menu, between Edit Plan… and Rename…), which opens the wizard **pre-seeded from the source plan** — only the destination (and password) need deciding. The Edit Plan window's locked-destination footnote now points at the new action.

## How it works

- `WizardModel.loadForDuplicate(from:)` copies every non-secret setting: name gets a Finder-style *"copy"* suffix, then folders, schedule, verification cadence, retention, excludes, backup/performance knobs, and the destination fields (S3 access key ID prefilled; secrets never are — they are Keychain entries keyed by the source plan's UUID, and a duplicate is a new plan with a new UUID).
- The wizard is reused as a second window scene (`WindowID.duplicatePlan`) with the same three steps, so every destination form, validation message, conflict rule and the "connect to an existing repository" flow is shared — zero duplicated destination UI. The unchanged source destination trips the step's existing red *"Another plan already backs up to this destination…"* callout, which tells the user exactly what to do: change it, or adopt the existing repository.
- Creation goes through the unchanged `AppState.createPlan` / `PlanManager.createPlan`: new repo via `restic init` or adopt-with-password-verification, Keychain writes and rollback as always. Persistence untouched.

## Testing done

- `swift test --package-path KeelhavenCore`: 169 tests, 0 failures (3 integration skips as designed).
- Logic harness compiled against the app's real `WizardModel` + `PlanManager` + real restic 0.19.1 (36 checks): loadForDuplicate mapping for all four destination types (incl. *secrets never carried over*), unchanged-destination conflict / cleared-on-change / adopt-allows-shared-repo, and real duplicate creation end-to-end — fresh UUID, repo init'd, password stored under the *new* UUID, second init on the same folder refused, adopt of the same repository succeeding.
- End-to-end UI run via the Accessibility API against a debug build with an isolated Application Support dir (real user data untouched, restored afterwards): ⋯ → Duplicate Plan… → window opens titled "Duplicate Backup Plan" → seeded folders listed → destination prefilled + conflict callout shown → typing a new destination clears the conflict → password section appears → Next → summary shows name "Documents copy".

## Localization

New strings added to `Localizable.xcstrings` with zh-Hans translations, including the new menu/window titles and the reworded Edit Plan footnote (old footnote key removed).
